### PR TITLE
Session observation seam + honest OBSERVE mode

### DIFF
--- a/axor_core/context/manager.py
+++ b/axor_core/context/manager.py
@@ -56,6 +56,7 @@ class ContextManager:
         self._all_fragments: list[ContextFragment] = []
         self._pinned_fragments: list[ContextFragment] = []  # never compressed/evicted
         self._recent_outputs: list[str] = []
+        self._last_view: ContextView | None = None  # most recent build() output, for read-only taps
 
     def pin_fragment(self, fragment: ContextFragment) -> None:
         """
@@ -189,7 +190,7 @@ class ContextManager:
         final = list(self._pinned_fragments) + selected
         total_tokens = sum(f.token_estimate for f in final)
 
-        return ContextView(
+        view = ContextView(
             node_id=lineage.node_id,
             working_summary=self._build_summary(raw_state, final, policy),
             visible_fragments=final,
@@ -197,6 +198,29 @@ class ContextManager:
             lineage=lineage,
             token_count=total_tokens,
             compression_ratio=compression_result.compression_ratio,
+        )
+        self._last_view = view
+        return view
+
+    def context_window_view(self, limit: int = 50) -> tuple[dict, ...]:
+        """
+        Read-only, bounded snapshot of the most recently built context window.
+
+        Returns the last build()'s visible fragments as plain dicts (most recent
+        last), capped at `limit`. Empty tuple if no turn has been built yet.
+        Pure read — does not mutate context or advance any turn counter.
+        """
+        if self._last_view is None:
+            return ()
+        fragments = self._last_view.visible_fragments[-limit:]
+        return tuple(
+            {
+                "kind": f.kind,
+                "source": f.source,
+                "content": f.content,
+                "turn": getattr(f, "turn", None),
+            }
+            for f in fragments
         )
 
     def update(self, result_output: str, node_id: str) -> None:

--- a/axor_core/contracts/observation.py
+++ b/axor_core/contracts/observation.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, Protocol, runtime_checkable
+
+
+# ── Neutral observation DTOs ────────────────────────────────────────────────────
+#
+# axor-core owns these shapes. They carry *raw facts* only — no bucketing,
+# normalization, or consumer-specific vocabulary. Downstream observers
+# (axor-probe, axor-sentinel) translate them into their own types:
+#
+#   SessionContextView  → axor-probe StateSnapshot / CanonicalizedContextSummary
+#   SessionAuditRecord  → axor-sentinel SessionSummary / ResourceAccess
+#
+# axor-core never imports the consumers — dependency direction is strictly
+# one-way (P-34). Consumers attach by implementing the Protocols below.
+
+
+@dataclass(frozen=True)
+class ToolInvocationRecord:
+    """
+    A single tool invocation observed within a session.
+
+    Raw material only. `args` is the unmodified tool argument mapping as seen by
+    the capability executor — consumers derive resource identity / signal grading
+    from it (axor-sentinel runs its own resource normalizer over `tool` + `args`).
+    """
+
+    tool: str
+    args: Mapping[str, object]
+    executed: bool  # True if the tool ran; False if the intent was denied before execution
+
+
+@dataclass(frozen=True)
+class SessionContextView:
+    """
+    Read-only, bounded, hash-only view of live session context at a trigger point.
+
+    Owned by axor-core; never persisted by core (P-10). It carries the real
+    bounded context window because an in-process probe instance needs it to
+    measure drift — but it stays in-process: only redacted signals are exported
+    downstream (P-11). The system prompt is exposed as a hash only, never text.
+
+    Structural facts are raw. Consumers bucket them (e.g. axor-probe derives
+    CanonicalizedContextSummary.data_sensitivity from `taint_sources` /
+    `external_read_count`).
+    """
+
+    session_id: str
+    agent_id: str
+    timestamp: float
+    turn_index: int
+    token_count: int
+    context_window: tuple[Mapping[str, object], ...]  # bounded slice; bound owned by core
+    system_prompt_hash: str                           # hash only — never plaintext (P-11)
+    taint_active: bool
+    taint_sources: tuple[str, ...]                    # TaintSource.value
+    taint_scope: str                                  # TaintScope.value
+    taint_intent_age: int
+    external_read_count: int
+
+
+@dataclass(frozen=True)
+class SessionAuditRecord:
+    """
+    Raw end-of-session facts, built from the session's DecisionTraces and the
+    final TaintState. axor-core's vocabulary, not the consumer's — the mapping
+    into axor-sentinel SessionSummary (had_export_attempt, had_failed_export,
+    had_escalation, ResourceAccess grading) is done by the consumer.
+    """
+
+    session_id: str
+    agent_id: str
+    started_at: float
+    ended_at: float
+    taint_active: bool
+    taint_sources: tuple[str, ...]                    # TaintSource.value
+    event_kinds: tuple[str, ...]                      # distinct TraceEventKind.value seen this session
+    tool_invocations: tuple[ToolInvocationRecord, ...]
+
+
+# ── Observer Protocols ──────────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class ContextTap(Protocol):
+    """
+    Mid-session, read-only context tap.
+
+    axor-core calls on_context_event() at each turn boundary when at least one
+    tap is registered. Gating (whether a probe should actually fire) lives in the
+    consumer — core emits unconditionally and cheaply.
+
+    Implementations MUST return promptly and MUST NOT block the governance path:
+    out-of-band work (e.g. probe inference) must be scheduled on a separate task.
+    Implementations MUST NOT raise — the caller catches and logs, but a slow or
+    throwing tap still degrades the governed turn it rides on.
+
+    Canonical implementation: axor_probe.integration.core_tap.CoreContextTap.
+    """
+
+    async def on_context_event(self, view: SessionContextView) -> None: ...
+
+
+@runtime_checkable
+class SessionSink(Protocol):
+    """
+    End-of-session audit sink.
+
+    axor-core calls on_session_closed() once during GovernedSession.aclose()
+    when at least one sink is registered. Naturally out-of-band — the consumer
+    (e.g. axor-sentinel) buffers the record for its next background audit cycle.
+
+    Implementations MUST NOT raise — failures are caught and logged by core.
+
+    Canonical implementation: axor_sentinel.integration.core_sink.CoreSessionSink.
+    """
+
+    async def on_session_closed(self, record: SessionAuditRecord) -> None: ...

--- a/axor_core/node/intent_loop.py
+++ b/axor_core/node/intent_loop.py
@@ -125,6 +125,7 @@ class IntentLoop:
         reputation_enricher: "ReputationEnricher | None" = None,
         max_intents_per_session: int | None = None,
         max_total_spawns: int | None = None,
+        observe: bool = False,
     ) -> None:
         self._executor = capability_executor
         self._trace_events = trace_events
@@ -150,6 +151,11 @@ class IntentLoop:
         self._max_intents_per_session = max_intents_per_session
         self._max_total_spawns = max_total_spawns
         self._spawn_count = 0
+        # OBSERVE mode (evaluation): governance still resolves every intent and
+        # records what it WOULD deny, but never blocks — the tool executes and
+        # the real result is returned, so measurement is uncontaminated by
+        # enforcement. Denials are recorded as INTENT_DENIED with observed=True.
+        self._observe = observe
 
     async def run(
         self,
@@ -346,26 +352,18 @@ class IntentLoop:
             reason = (
                 f"session intent limit reached ({self._max_intents_per_session})"
             )
-            self._record_denial(intent, reason, envelope)
-            return ResolvedIntent(
-                intent=intent,
-                approved=False,
-                reason=reason,
-                result=_denial_result(tool_name, reason),
-            )
+            resolved = self._blocked(intent, reason, envelope, _denial_result(tool_name, reason))
+            if resolved is not None:
+                return resolved
 
         decision = self._evaluate_tool_intent(intent, envelope)
 
         if decision.kind == PolicyDecisionKind.DENY:
-            self._record_denial(intent, decision.reason, envelope)
             denial_resp = _make_denial_response(decision.reason)
             self._record_degradation_signal(intent, denial_resp)
-            return ResolvedIntent(
-                intent=intent,
-                approved=False,
-                reason=decision.reason,
-                result=denial_resp.to_tool_result(),
-            )
+            resolved = self._blocked(intent, decision.reason, envelope, denial_resp.to_tool_result())
+            if resolved is not None:
+                return resolved
 
         # normalize intent once — shared by anomaly detection, taint, degradation, and reputation
         needs_normalized = (
@@ -397,17 +395,13 @@ class IntentLoop:
                 f"{normalized.target_resource_reputation:.3f} >= 0.8 "
                 "and session preceded by external read"
             )
-            self._record_denial(intent, reason, envelope)
             denial_resp = _make_denial_response(reason, "high_reputation_resource_tainted_access")
             # DegradationEngine interaction: reputation deny contributes to tool_pressure_count
             # per spec §DegradationEngine interaction.
             self._record_degradation_signal(intent, denial_resp, normalized)
-            return ResolvedIntent(
-                intent=intent,
-                approved=False,
-                reason=reason,
-                result=denial_resp.to_tool_result(),
-            )
+            resolved = self._blocked(intent, reason, envelope, denial_resp.to_tool_result())
+            if resolved is not None:
+                return resolved
 
         # degradation pre-check — enforce narrowed policy from previous signals
         if self._degradation_engine is not None and normalized is not None:
@@ -416,15 +410,11 @@ class IntentLoop:
                 tool_name, normalized, taint_state, envelope
             )
             if degradation_denial is not None:
-                self._record_denial(intent, degradation_denial, envelope)
                 denial_resp = _make_denial_response(degradation_denial)
                 self._record_degradation_signal(intent, denial_resp, normalized)
-                return ResolvedIntent(
-                    intent=intent,
-                    approved=False,
-                    reason=degradation_denial,
-                    result=denial_resp.to_tool_result(),
-                )
+                resolved = self._blocked(intent, degradation_denial, envelope, denial_resp.to_tool_result())
+                if resolved is not None:
+                    return resolved
 
         # anomaly detection — runs after policy approval
         # A-11: pass pre-enrichment normalized (reputation floats at 0.0) to Layer 2
@@ -440,15 +430,13 @@ class IntentLoop:
             except Exception as exc:
                 reason = f"anomaly detector raised unexpectedly: {type(exc).__name__}: {exc}"
                 log.error("anomaly detector error — failing closed: %s", exc, exc_info=True)
-                self._record_denial(intent, reason, envelope)
                 denial_resp = _make_denial_response(reason, "anomaly_detector_error")
                 self._record_degradation_signal(intent, denial_resp, normalized)
-                return ResolvedIntent(
-                    intent=intent,
-                    approved=False,
-                    reason=reason,
-                    result=denial_resp.to_tool_result(),
-                )
+                resolved = self._blocked(intent, reason, envelope, denial_resp.to_tool_result())
+                if resolved is not None:
+                    return resolved
+                # observe fall-through: scoring failed, treat as no anomaly signal.
+                anomaly = None
 
             if anomaly is not None and anomaly.cls == AnomalyClass.CRITICAL:
                 reason = f"anomaly detector: CRITICAL score={anomaly.score:.2f} reasons={anomaly.reasons}"
@@ -456,16 +444,12 @@ class IntentLoop:
                     tool_name=tool_name,
                     normalized=normalized,
                     anomaly=anomaly,
-                    policy_action="denied",
+                    policy_action="observed" if self._observe else "denied",
                     envelope=envelope,
                 )
-                self._record_denial(intent, reason, envelope)
-                return ResolvedIntent(
-                    intent=intent,
-                    approved=False,
-                    reason=reason,
-                    result=_denial_result(tool_name, reason),
-                )
+                resolved = self._blocked(intent, reason, envelope, _denial_result(tool_name, reason))
+                if resolved is not None:
+                    return resolved
 
             if anomaly is not None and anomaly.cls == AnomalyClass.SUSPICIOUS:
                 self._record_anomaly_event(
@@ -516,15 +500,11 @@ class IntentLoop:
                     "(writes_outside_workdir, executes_generated_code, or "
                     "exfiltration to a cloud-metadata/private-network destination)"
                 )
-                self._record_denial(intent, reason, envelope)
                 denial_resp = _make_denial_response(reason, "taint_enforcement")
                 self._record_degradation_signal(intent, denial_resp, normalized)
-                return ResolvedIntent(
-                    intent=intent,
-                    approved=False,
-                    reason=reason,
-                    result=denial_resp.to_tool_result(),
-                )
+                resolved = self._blocked(intent, reason, envelope, denial_resp.to_tool_result())
+                if resolved is not None:
+                    return resolved
 
         # approved or transformed — emit the appropriate trace event
         is_transform = decision.kind == PolicyDecisionKind.TRANSFORM
@@ -546,9 +526,16 @@ class IntentLoop:
             sequence=self._intent_sequence,
         )
 
+        caps = envelope.capabilities
+        if self._observe and tool_name not in caps.allowed_tools:
+            # OBSERVE: the capability gate must not block measurement. The policy
+            # denial is already recorded above as observed-only; grant the
+            # requested tool for this single call so the real result is produced.
+            from dataclasses import replace as _dc_replace
+            caps = _dc_replace(caps, allowed_tools=caps.allowed_tools | {tool_name})
         try:
             result = await self._executor.execute(
-                effective_intent, envelope.capabilities
+                effective_intent, caps
             )
             # Propagate taint after any successful privileged read.
             if self._taint_engine is not None:
@@ -886,6 +873,7 @@ class IntentLoop:
         intent: Intent,
         reason: str,
         envelope: ExecutionEnvelope,
+        observed: bool = False,
     ) -> None:
         self._trace_events.append(
             IntentDeniedEvent(
@@ -894,7 +882,32 @@ class IntentLoop:
                 sequence=len(self._trace_events),
                 intent_kind=intent.kind.value,
                 reason=reason,
+                payload={"observed": observed},
             )
+        )
+
+    def _blocked(
+        self,
+        intent: Intent,
+        reason: str,
+        envelope: ExecutionEnvelope,
+        denial_result: object,
+    ) -> "ResolvedIntent | None":
+        """
+        Record that governance flagged this intent, then decide enforcement.
+
+        Enforce mode → return the denial ResolvedIntent (caller returns it).
+        Observe mode → record the denial as observed-only and return None, so the
+        caller falls through to execute the tool and return the real result.
+        """
+        self._record_denial(intent, reason, envelope, observed=self._observe)
+        if self._observe:
+            return None
+        return ResolvedIntent(
+            intent=intent,
+            approved=False,
+            reason=reason,
+            result=denial_result,
         )
 
     def _record_anomaly_event(

--- a/axor_core/node/wrapper.py
+++ b/axor_core/node/wrapper.py
@@ -88,6 +88,7 @@ class GovernedNode:
         degradation_engine: "DegradationEngine | None" = None,
         max_intents_per_session: int | None = 1000,
         max_total_spawns: int | None = 200,
+        observe: bool = False,
     ) -> None:
         self._executor = executor
         self._child_executor = child_executor  # None → reuse parent executor
@@ -106,6 +107,7 @@ class GovernedNode:
         self._degradation_engine = degradation_engine
         self._max_intents_per_session = max_intents_per_session
         self._max_total_spawns = max_total_spawns
+        self._observe = observe
 
         self._envelope_builder = EnvelopeBuilder()
         self._export_filter = ExportFilter()
@@ -277,6 +279,7 @@ class GovernedNode:
             degradation_engine=self._degradation_engine,
             max_intents_per_session=self._max_intents_per_session,
             max_total_spawns=self._max_total_spawns,
+            observe=self._observe,
         )
 
         raw_output, raw_payload = await self._collect_stream(
@@ -398,7 +401,8 @@ class GovernedNode:
                 spawn_intent=intent,
                 parent_envelope=envelope,
                 intent_loop=IntentLoop(
-                    self._cap_executor, trace_events, self._depth
+                    self._cap_executor, trace_events, self._depth,
+                    observe=self._observe,
                 ),
                 trace_events=trace_events,
             )

--- a/axor_core/worker/session.py
+++ b/axor_core/worker/session.py
@@ -233,10 +233,15 @@ class GovernedSession:
         # taint engine — persists across turns so taint is sticky within a session
         self._taint_engine = TaintEngine(node_id=self._session_id)
 
-        # degradation engine — persists across turns; level is monotonically increasing
+        # degradation engine — persists across turns; level is monotonically increasing.
+        # In OBSERVE mode it records signals/transitions but never escalates or locks.
         from axor_core.degradation.engine import DegradationEngine
         from axor_core.contracts.degradation import DegradationPolicy
-        self._degradation_engine = DegradationEngine(DegradationPolicy(), node_id=self._session_id)
+        self._degradation_engine = DegradationEngine(
+            DegradationPolicy(),
+            node_id=self._session_id,
+            observe=(mode == ExecutionMode.OBSERVE),
+        )
 
     @staticmethod
     def _enforce_isolation_policy(
@@ -619,6 +624,7 @@ class GovernedSession:
             anomaly_detector=self._anomaly_detector,
             taint_engine=self._taint_engine,
             degradation_engine=self._degradation_engine,
+            observe=(self._mode == ExecutionMode.OBSERVE),
         )
 
     async def _handle_command(self, raw: str) -> ExecutionResult:

--- a/axor_core/worker/session.py
+++ b/axor_core/worker/session.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
+import time
 import uuid
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +15,13 @@ from axor_core.contracts.context import RawExecutionState, LineageSummary
 from axor_core.contracts.extension import ExtensionLoader
 from axor_core.contracts.anomaly import AnomalyDetector
 from axor_core.contracts.drift import BehavioralDriftObserver
+from axor_core.contracts.observation import (
+    ContextTap,
+    SessionAuditRecord,
+    SessionContextView,
+    SessionSink,
+    ToolInvocationRecord,
+)
 from axor_core.contracts.invokable import Invokable
 from axor_core.contracts.mode import ExecutionMode
 from axor_core.contracts.policy import ExecutionPolicy, SignalClassifier
@@ -89,6 +98,8 @@ class GovernedSession:
         classifier: SignalClassifier | None = None,
         anomaly_detector: AnomalyDetector | None = None,
         behavioral_drift_observer: BehavioralDriftObserver | None = None,
+        context_taps: list[ContextTap] | None = None,
+        session_sinks: list[SessionSink] | None = None,
         extension_loaders: list[ExtensionLoader] | None = None,
         trace_config: TraceConfig | None = None,
         soft_token_limit: int | None = None,
@@ -104,6 +115,18 @@ class GovernedSession:
         self._session_id     = f"session_{uuid.uuid4().hex[:12]}"
         self._mode           = mode
         self._behavioral_drift_observer = behavioral_drift_observer
+
+        # Read-only session observation taps/sinks (P-34: consumers attach here;
+        # core never imports them). All emission is fail-safe and out-of-band.
+        self._context_taps   = list(context_taps) if context_taps else []
+        self._session_sinks  = list(session_sinks) if session_sinks else []
+        self._started_at     = time.time()
+        self._turn_index     = 0
+        self._external_read_count = 0
+        # Raw tool-invocation log for the end-of-session audit record. Bounded so a
+        # long session cannot grow it without limit; consumers get the tail.
+        self._tool_log: list[ToolInvocationRecord] = []
+        self._tool_log_cap   = 500
 
         # STRICT mode is a superset of PRODUCTION.
         # Apply all STRICT-only restrictions here before anything else is wired.
@@ -327,7 +350,15 @@ class GovernedSession:
                     path = args.get("path", "")
                     if path:
                         self._context_manager.record_file_read(path, result)
+                        self._external_read_count += 1
                 self._context_manager.cache_tool_result(tool_name, args, result)
+                # Raw tool-invocation log for the end-of-session audit record.
+                if len(self._tool_log) < self._tool_log_cap:
+                    self._tool_log.append(ToolInvocationRecord(
+                        tool=tool_name,
+                        args=dict(args) if isinstance(args, dict) else {},
+                        executed=True,
+                    ))
             self._cap_executor.register_post_callback(_context_observer)
             self._context_observer_registered = True
 
@@ -386,7 +417,55 @@ class GovernedSession:
             except Exception:
                 pass
 
+        # Read-only context tap (out-of-band, fail-safe). Emitted once per turn
+        # when at least one tap is registered. Consumers gate / schedule probes.
+        self._turn_index += 1
+        await self._emit_context_event()
+
         return result
+
+    def _agent_id(self) -> str:
+        return self._agent_def.name if self._agent_def is not None else self._session_id
+
+    def _build_context_view(self) -> SessionContextView:
+        taint = self._taint_engine.state
+        # system prompt is exposed as a hash only (P-11) — derive from the pinned
+        # personality fragment if present; never the plaintext.
+        prompt_src = ""
+        if self._agent_def is not None and self._agent_def.personality:
+            prompt_src = self._agent_def.personality
+        prompt_hash = hashlib.sha256(prompt_src.encode("utf-8")).hexdigest() if prompt_src else ""
+        return SessionContextView(
+            session_id=self._session_id,
+            agent_id=self._agent_id(),
+            timestamp=time.time(),
+            turn_index=self._turn_index,
+            token_count=self._tracker.total_tokens(),
+            context_window=self._context_manager.context_window_view(),
+            system_prompt_hash=prompt_hash,
+            taint_active=taint.is_tainted,
+            taint_sources=tuple(s.value for s in taint.sources),
+            taint_scope=taint.scope.value,
+            taint_intent_age=taint.intent_age,
+            external_read_count=self._external_read_count,
+        )
+
+    async def _emit_context_event(self) -> None:
+        if not self._context_taps:
+            return
+        try:
+            view = self._build_context_view()
+        except Exception:
+            _log.error("context view build failed session=%s", self._session_id, exc_info=True)
+            return
+        for tap in self._context_taps:
+            try:
+                await tap.on_context_event(view)
+            except Exception:
+                _log.error(
+                    "context_tap.on_context_event failed session=%s", self._session_id,
+                    exc_info=True,
+                )
 
     async def notify_behavioral_drift(self, agent_id: str, action: str) -> None:
         """
@@ -413,6 +492,40 @@ class GovernedSession:
                 exc_info=True,
             )
 
+    def _build_audit_record(self) -> SessionAuditRecord:
+        taint = self._taint_engine.state
+        kinds: set[str] = set()
+        for trace in self._collector.all_traces():
+            for event in trace.events:
+                kinds.add(event.kind.value)
+        return SessionAuditRecord(
+            session_id=self._session_id,
+            agent_id=self._agent_id(),
+            started_at=self._started_at,
+            ended_at=time.time(),
+            taint_active=taint.is_tainted,
+            taint_sources=tuple(s.value for s in taint.sources),
+            event_kinds=tuple(sorted(kinds)),
+            tool_invocations=tuple(self._tool_log),
+        )
+
+    async def _emit_session_closed(self) -> None:
+        if not self._session_sinks:
+            return
+        try:
+            record = self._build_audit_record()
+        except Exception:
+            _log.error("audit record build failed session=%s", self._session_id, exc_info=True)
+            return
+        for sink in self._session_sinks:
+            try:
+                await sink.on_session_closed(record)
+            except Exception:
+                _log.error(
+                    "session_sink.on_session_closed failed session=%s", self._session_id,
+                    exc_info=True,
+                )
+
     def cancel(self, detail: str = "") -> None:
         """
         Cancel the current active execution.
@@ -427,6 +540,9 @@ class GovernedSession:
         memory provider. Idempotent. Safe to call even if start() was never
         invoked.
         """
+        # End-of-session audit sink (out-of-band, fail-safe). Built before the
+        # collector closes so trace events are still available.
+        await self._emit_session_closed()
         self._collector.close()
         if self._telemetry is not None:
             close = getattr(self._telemetry, "aclose", None)

--- a/tests/worker/test_observe_no_deny.py
+++ b/tests/worker/test_observe_no_deny.py
@@ -1,0 +1,83 @@
+"""OBSERVE mode: governance resolves and records denials but never blocks.
+
+In ExecutionMode.OBSERVE the IntentLoop still evaluates every intent against
+policy/taint/degradation and records what it WOULD deny (INTENT_DENIED with
+observed=True), but the tool executes anyway and returns its real result, so
+evaluation measurement is uncontaminated by enforcement.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from axor_core import GovernedSession, presets
+from axor_core.capability.executor import CapabilityExecutor, ToolHandler
+from axor_core.contracts.mode import ExecutionMode
+from axor_core.contracts.trace import TraceEventKind
+from axor_core.contracts.trace import TraceConfig
+from tests.conftest import EchoExecutor
+
+
+class _TrackingBash(ToolHandler):
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    @property
+    def name(self) -> str:
+        return "bash"
+
+    async def execute(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        return "bash output"
+
+
+def _session(handler, mode):
+    cap = CapabilityExecutor()
+    cap.register(handler)
+    return GovernedSession(
+        executor=EchoExecutor(tool_calls=[("bash", {"cmd": "ls"})]),
+        capability_executor=cap,
+        mode=mode,
+        trace_config=TraceConfig(local_only=True, persist_inputs=False),
+    )
+
+
+def _events(session, kind):
+    out = []
+    for trace in session.all_traces():
+        out.extend(e for e in trace.events if e.kind == kind)
+    return out
+
+
+def _denied_events(session):
+    return _events(session, TraceEventKind.INTENT_DENIED)
+
+
+def _approved_events(session):
+    return _events(session, TraceEventKind.INTENT_APPROVED)
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_blocks_denied_tool():
+    handler = _TrackingBash()
+    session = _session(handler, ExecutionMode.LIBRARY)
+    await session.run("do something", policy=presets.get("readonly"))  # readonly denies bash
+    assert handler.calls == []                      # tool never executed
+    denied = _denied_events(session)
+    assert len(denied) >= 1
+    assert denied[0].payload.get("observed") is False
+
+
+@pytest.mark.asyncio
+async def test_observe_mode_records_denial_but_executes():
+    handler = _TrackingBash()
+    session = _session(handler, ExecutionMode.OBSERVE)
+    await session.run("do something", policy=presets.get("readonly"))
+    # OBSERVE: the would-be-denied tool actually ran...
+    assert handler.calls == [{"cmd": "ls"}]
+    # ...and the denial is recorded as observed-only, plus an approval/execution.
+    denied = _denied_events(session)
+    assert len(denied) >= 1
+    assert denied[0].payload.get("observed") is True
+    assert len(_approved_events(session)) >= 1

--- a/tests/worker/test_session_observation.py
+++ b/tests/worker/test_session_observation.py
@@ -1,0 +1,135 @@
+"""Session observation taps/sinks — read-only context tap and end-of-session sink.
+
+These verify the P-34-clean integration seam: core emits neutral SessionContextView
+and SessionAuditRecord facts to structurally-attached observers, fail-safe and
+out-of-band, without importing any consumer (axor-probe / axor-sentinel).
+"""
+from __future__ import annotations
+
+import pytest
+
+from axor_core import GovernedSession
+from axor_core.contracts.observation import SessionAuditRecord, SessionContextView
+from axor_core.contracts.trace import TraceConfig
+from tests.conftest import EchoExecutor
+
+
+class _CollectingTap:
+    def __init__(self) -> None:
+        self.views: list[SessionContextView] = []
+
+    async def on_context_event(self, view: SessionContextView) -> None:
+        self.views.append(view)
+
+
+class _CollectingSink:
+    def __init__(self) -> None:
+        self.records: list[SessionAuditRecord] = []
+
+    async def on_session_closed(self, record: SessionAuditRecord) -> None:
+        self.records.append(record)
+
+
+class _RaisingTap:
+    async def on_context_event(self, view: SessionContextView) -> None:
+        raise RuntimeError("tap boom")
+
+
+class _RaisingSink:
+    async def on_session_closed(self, record: SessionAuditRecord) -> None:
+        raise RuntimeError("sink boom")
+
+
+def _session(executor, cap_executor, **kw):
+    return GovernedSession(
+        executor=executor,
+        capability_executor=cap_executor,
+        trace_config=TraceConfig(local_only=True, persist_inputs=False),
+        **kw,
+    )
+
+
+class TestContextTap:
+    @pytest.mark.asyncio
+    async def test_tap_receives_one_view_per_turn(self, echo_executor, cap_executor):
+        tap = _CollectingTap()
+        session = _session(echo_executor, cap_executor, context_taps=[tap])
+        await session.run("write a test")
+        await session.run("explain this")
+        assert len(tap.views) == 2
+        assert tap.views[0].turn_index == 1
+        assert tap.views[1].turn_index == 2
+
+    @pytest.mark.asyncio
+    async def test_view_carries_neutral_facts(self, echo_executor, cap_executor):
+        tap = _CollectingTap()
+        session = _session(echo_executor, cap_executor, context_taps=[tap])
+        await session.run("write a test")
+        view = tap.views[0]
+        assert view.session_id == session.session_id()
+        assert isinstance(view.context_window, tuple)
+        assert view.token_count > 0
+        # taint not raised on a clean run
+        assert view.taint_active is False
+        assert view.taint_scope  # non-empty TaintScope.value
+
+    @pytest.mark.asyncio
+    async def test_external_read_count_increments_on_read(self, cap_executor):
+        executor = EchoExecutor(tool_calls=[("read", {"path": "auth.py"})])
+        tap = _CollectingTap()
+        session = _session(executor, cap_executor, context_taps=[tap])
+        await session.run("write a test for the auth module")
+        assert tap.views[0].external_read_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_no_tap_means_no_emission(self, echo_executor, cap_executor):
+        # No taps registered → run completes normally, nothing to observe.
+        session = _session(echo_executor, cap_executor)
+        result = await session.run("write a test")
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_raising_tap_does_not_break_run(self, echo_executor, cap_executor):
+        session = _session(echo_executor, cap_executor, context_taps=[_RaisingTap()])
+        result = await session.run("write a test")
+        assert result is not None  # governance path unaffected by tap failure
+
+
+class TestSessionSink:
+    @pytest.mark.asyncio
+    async def test_sink_receives_record_on_close(self, echo_executor, cap_executor):
+        sink = _CollectingSink()
+        session = _session(echo_executor, cap_executor, session_sinks=[sink])
+        await session.run("write a test")
+        assert sink.records == []  # not emitted mid-session
+        await session.aclose()
+        assert len(sink.records) == 1
+        rec = sink.records[0]
+        assert rec.session_id == session.session_id()
+        assert isinstance(rec.event_kinds, tuple) and len(rec.event_kinds) > 0
+
+    @pytest.mark.asyncio
+    async def test_record_captures_tool_invocation(self, cap_executor):
+        executor = EchoExecutor(tool_calls=[("read", {"path": "auth.py"})])
+        sink = _CollectingSink()
+        session = _session(executor, cap_executor, session_sinks=[sink])
+        await session.run("write a test for the auth module")
+        await session.aclose()
+        rec = sink.records[0]
+        tools = [ti.tool for ti in rec.tool_invocations]
+        assert "read" in tools
+        read_inv = next(ti for ti in rec.tool_invocations if ti.tool == "read")
+        assert read_inv.executed is True
+        assert read_inv.args.get("path") == "auth.py"
+
+    @pytest.mark.asyncio
+    async def test_no_sink_means_no_emission(self, echo_executor, cap_executor):
+        session = _session(echo_executor, cap_executor)
+        await session.run("write a test")
+        await session.aclose()  # must not raise without sinks
+
+    @pytest.mark.asyncio
+    async def test_raising_sink_does_not_break_close(self, echo_executor, cap_executor):
+        session = _session(echo_executor, cap_executor, session_sinks=[_RaisingSink()])
+        await session.run("write a test")
+        await session.aclose()  # swallowed


### PR DESCRIPTION
## Summary

Two additive, P-34-clean changes to the kernel.

**1. Session observation seam.** A neutral, read-only tap so downstream consumers attach without core importing them.
- `contracts/observation.py`: `SessionContextView`, `SessionAuditRecord`, `ToolInvocationRecord` (raw facts only) + `ContextTap` / `SessionSink` Protocols.
- `GovernedSession`: optional `context_taps` / `session_sinks`. Mid-session context tap per turn; end-of-session audit sink in `aclose()`. Both fail-safe + out-of-band, zero overhead when unused.
- `ContextManager.context_window_view()` as the bounded, non-mutating snapshot source.
- System prompt exposed as hash only (P-11); view never persisted by core (P-10).

**2. Honest OBSERVE mode.** In `ExecutionMode.OBSERVE` the full IntentLoop runs — policy / reputation / degradation / anomaly / taint all resolve and **record what they would deny** (`INTENT_DENIED` with `observed=True`) — but nothing is blocked: the tool executes and the real result is returned, so evaluation is uncontaminated by enforcement. The capability gate is bypassed in observe; `GovernedSession`/`GovernedNode` plumb the flag and build the DegradationEngine in observe mode.

Enforce modes (LIBRARY/PRODUCTION/STRICT) are unchanged (`observe=False`).

## Downstream
This is the contract foundation for axor-probe (`CoreContextTap`), axor-sentinel (`CoreSessionSink`), and the governed evaluation path in axor-eval — all of which target the same branch.

## Tests
`tests/worker/test_session_observation.py` (9) + `tests/worker/test_observe_no_deny.py` (2). Full suite: **531 passed, 1 xfailed**.

https://claude.ai/code/session_017iLB163HUDCXynLwUaA3bz

---
_Generated by [Claude Code](https://claude.ai/code/session_017iLB163HUDCXynLwUaA3bz)_