### PR TITLE
paper: split outline into clean skeleton + decisions log; add workspace/paired-run data

### DIFF
--- a/docs/paper-decisions.md
+++ b/docs/paper-decisions.md
@@ -1,0 +1,216 @@
+# Axor paper — decisions log, canon lock & drafting rules
+
+Companion to `docs/paper-outline.md`. The outline is the skeleton of the paper; this
+file is the process memory behind it — the canon number lock, resolved decisions with
+their rationale, retired numbers that must never reappear, drafting rules, and the open
+questions for Haoyu. Nothing here goes into the paper verbatim except where marked.
+
+---
+
+## 0. ACTION ITEMS (blockers before drafting)
+
+1. **Update `examples/agentdojo/agentdojo_results.md` with the new paired runs.** The
+   outline now carries slack **−34.1 ± 7.2pp** (paired, n=7, 84.8 → 50.6), workspace
+   **−15.5 ± 3.8pp** (paired, n=7, 84.3 → 68.8, denial split 92 taint / 12
+   consequence-gate over ~104), and travel **paired n=2 (62.5 → 70.0, 0 denials)** —
+   but the results file still records slack as a single run (85.7 → 47.6, −38.1) and
+   travel as a single run (65.0 → 65.0), with no workspace cost section. The canon rule
+   ("every number traces to `agentdojo_results.md`") is currently violated for these
+   three rows. Land the new runs in the results file (with reproduction commands,
+   Appendix C) before any §6 prose is drafted.
+2. **Consider extending travel to n=7** for symmetry with the other suites. Cheap; its
+   0 is structural (zero denials) so the conclusion cannot change, but "7/7/7/2" invites
+   a question that "7/7/7/7" doesn't. If not extended, §8 states the n honestly (done).
+3. **Pin the missing citations:** the exact nested/recursive-injection follow-up to
+   Greshake et al. (§6.5), and the IFC ancestors for the §7 lineage bullet
+   (Sabelfeld & Myers JSAC 2003; Zdancewic & Myers robust declassification; DLM).
+4. **Build the Appendix E integration-cost table** (per framework: normalizer LOC,
+   agent-loop changes = 0, policy changes = 0) — it turns §6.5's adoption claim from
+   assertion into data.
+
+---
+
+## 1. Canon lock — the authoritative numbers
+
+Source of record: `examples/agentdojo/agentdojo_results.md` (after action item 1 lands).
+Every number in §1/§2/§6 must trace to it.
+
+**Cost axis (primary, o4-mini, own-baseline paired deltas):**
+
+| suite | undef → gov | cost | n | note |
+|---|---|---|---|---|
+| banking | 67.9% → 50.9% | **−17.0 ± 7.2pp** | 7 paired | worst single pass −37.5 (not the headline) |
+| slack | 84.8% → 50.6% | **−34.1 ± 7.2pp** | 7 paired | supersedes single-run −38.1 |
+| workspace | 84.3% → 68.8% | **−15.5 ± 3.8pp** | 7 paired | ~88% shared-channel taint / ~12% `delete` consequence gate (92/12 of ~104 denials) |
+| travel | 62.5% → 70.0% | **0 (structural)** | 2 paired | 0 denials/pass; the +7.5pp is sampling noise, never report as a gain |
+
+**Supersession (banking):** gate-level ceiling **+25pp** (deterministic, 4-task
+partition {3,4,6,15}); realized **+13.4 ± 9.1pp** (7 paired passes, same population;
+task 6 lifts at the gate but the model fails it 14/14 even undefended).
+
+**ASR illustration (never the cost axis):** GPT-4o banking **60.4% → 0.0%**; Qwen slack
+**76.2% → 0.0%**; Qwen banking-PII 66.7% → 0.0% (degenerate utility, 0 in both);
+claude-haiku banking 0% → 0% (robust model, expected degeneration).
+
+**CaMeL reference (version-pinned, never re-run):** arXiv:2503.18813**v2**, **Table 2
+(Difference, no-attack), o4-mini-high row only**: banking **+18.8 ± 1.8**, slack
+**−23.8 ± 7.6**, workspace **−7.5 ± 2.9**, travel **+10.0 ± 1.9**, overall −3.1 ± 0.4.
+Absolute for the own-baseline caveat: CaMeL native-slack 95.2 (vs our undefended 84.8 —
+never compare absolutes).
+
+**Statistics note (do this in the draft):** state once what "±" means (per-pass paired
+std over n passes) and n for every interval; a reviewer will compute the CI of
++13.4 ± 9.1 (n=7) themselves — pre-empt with the "wide interval, positive in every
+pass" framing.
+
+## 2. Retired / stale numbers — purge on sight
+
+- **slack −38.1pp (single run, 85.7 → 47.6)** — superseded by the paired −34.1 ± 7.2.
+- **travel 65.0 → 65.0 single run** — superseded by paired n=2 (62.5 → 70.0, structural 0).
+- **"slack = zero cost" (47.6 → 47.6)** — a **Qwen artifact**: Qwen fails the
+  shared-channel tasks anyway, so there was nothing to block. Retracted; the partition
+  is taxonomy-fixed but its cost scales with model capability. Only travel's 0 is
+  structural.
+- **"inverted profiles, axor strictly cheaper on slack"** — same Qwen artifact, retracted.
+- **54% / 56% utility** (early note) — stale, purge.
+- **CaMeL "−27 to −30pp"** — phantom, never existed in the tables.
+- **CaMeL cross-model averages ("≈0/+4% banking / −24..−43 slack")** — wrong axis
+  (averaging CaMeL over 6 backbones vs axor over o4-mini passes); use the o4-mini-high
+  row only. Per-model spread is context only: banking Difference +0.0 (Claude 4) …
+  +18.8 (o3/o4-mini) … −12.5 (Gemini Flash); slack −23.8 … −42.9.
+- **CaMeL Table 5 defenses-utility row (banking 75.0 / travel 25.0)** — a different,
+  weaker model; never cite as o4-mini.
+- **CaMeL Table 8's 58.33%** — a policy-trigger rate, not utility; never cite as utility.
+- **CaMeL "/75" headline figure** — unconfirmed; drop unless a specific table cell is found.
+- **NNSI 62% undefended** — self-refereed, never load-bearing (see drafting rules).
+- **"workspace not run for axor"** — stale since the 7-pass workspace study; §6 now
+  carries all four suites.
+
+## 3. Resolved decisions (with rationale)
+
+- **Measurement axis (the big one): lead with structural-guarantee-at-utility-cost
+  (§6.2), not ASR-delta.** ASR-delta is headroom-dependent and degenerates to 0→0 on
+  robust models; the guarantee+cost claim is CaMeL-shaped and survives any model. This
+  is the empirical analogue of §5.4's honesty and the real answer to "motivation for
+  adoption." ASR-delta (§6.4) is secondary colour.
+- **Baseline semantics — option (b), own-baseline cost profiles; CaMeL NOT re-run.**
+  A faithful re-implementation of CaMeL's interpreter is a project in itself; an
+  imperfect one would mislead more than a version-pinned reported reference. Fixed by
+  the §6.3 paper-ready methods statement (use verbatim). Cost was never the blocker
+  (~$5 for a slack run); the blocker is faithful interpreter re-implementation.
+- **CaMeL version pinned: v2** (arXiv:2503.18813v2). v1 (Mar 2025) used GPT-4o as a
+  defended backbone at ≈67%; v2 evaluates Claude 4 Sonnet / Gemini 2.5 Flash+Pro /
+  o3-high / o4-mini-high at ≈77% (77 vs 84 undefended) and references GPT-4o-mini only
+  as an instruction-hierarchy baseline/tokenizer. **o4-mini(-high) IS the shared
+  defended model between our runs and CaMeL v2 — that is why o4-mini is our primary
+  cost model and the §6.3 comparison is model-matched.** (This supersedes the earlier
+  "no shared defended model" note, which was true only when we ran GPT-4o alone; GPT-4o
+  has no v2 counterpart and is axor-only, used for §2/§6.4, never compared to CaMeL.)
+  Never write "the model CaMeL measured" except against v1 with v1's numbers.
+- **§2 suite choice: banking, resolved by a repo check.** The choice is decided by
+  *which axis the denial lands on*, not by drama. Verified against
+  `examples/agentdojo/config/`: slack declares only `untrusted_sources`, no
+  `sensitive_sources`, and the confidentiality floor arms only on a `sensitive`-rooted
+  read (`axor_core/taint/engine.py:101`). So the slack mass-exfil denial is
+  integrity/destination-taint (per-value taint on `post_webpage(url)`; whole-blob
+  carrier on the message sinks) — confirmed by `agentdojo_results.md` ("denied by the
+  per-value taint gate"). Slack therefore carries the *same* encoding/paraphrase
+  residual as banking and gains §2 nothing; banking stays the opener (cleanest
+  integrity gate-walk). The suite where the floor actually arms is **travel**
+  (`config/travel.yaml`, the only one with `sensitive_sources`) — this finding surfaced
+  the sound-axis demonstration, now placed as Appendix A-floor (a *property*, not an
+  AgentDojo result); travel is the natural second illustration. Not a swap; an addition.
+- **Confidentiality floor: placed as structural unit-level (Appendix A-floor), not a §6
+  result.** By-construction argument (gate reads a session boolean, never the egress
+  bytes — paraphrase-proof by signature) + deterministic illustration (arm → refuse →
+  paraphrase-still-refused → control-allows), reproduced live on OpenRouter/GPT-4o
+  while running travel. Name the axis asymmetry out loud: integrity = measured,
+  confidentiality = proven (§5.5). §6.2 keeps only the one-liner that the stock travel
+  slice does not isolate the floor. Optional, low priority: a targeted benign
+  read-secret-then-email harness only if a reviewer insists on a floor *cost* number.
+- **Novelty arbitration: one headline — the K4 theorem + decidability split (§5.4).**
+  §4 (seam) and §6 (empirics) are supporting. An earlier draft let §4 and §5.4 each
+  claim "the contribution"; fixed.
+- **How hard to push the theorem:** "stated + pinned + demonstrated on 2 trust models,"
+  explicitly *not* a mechanized proof. Keep the induction hedge identical everywhere:
+  **"argued by pen-and-paper induction over a closed constructor set (a Coq/Lean
+  target, not machine-checked)"** (§5.2/§5.6/§8).
+- **Enum-supersession placement:** full statement once in §6.3 + Appendix D; §1/§7/§9
+  carry one-line references only (it was previously restated in full ~5 times).
+
+## 4. Open decisions
+
+- **Venue framing:** systems-security (USENIX/CCS/S&P) vs an LLM-agent-safety venue —
+  changes how much §5 formalism vs §6 empiricism leads. Related: is the §6.5
+  "different, composable point on the cost/assurance/integration frontier" framing
+  enough for the venue, knowing CaMeL wins raw AgentDojo utility today? (= Q-venue for
+  Haoyu.)
+- **Section ordering:** Haoyu ranked framework-agnostic #1 for emphasis, but for a
+  security venue the theorem leads and §4 sits fourth (see Question 2 below).
+
+## 5. Drafting rules (style & honesty guardrails)
+
+- **Say "CaMeL is ahead on utility" plainly — once, in §6.3** (and the one-line echo in
+  §9). Do not re-litigate it in §1/§6.5/§7; repetition turns honesty into
+  self-deprecation. Equally: never soften it ("roughly comparable") — −34.1 vs −23.8 is
+  CaMeL ahead by ~10pp, say so.
+- **Never claim the gate covers "all attacks."** The guarantee covers the
+  projection-equivalence (framing) class, with the §5.4 conditionality (enum/numeric
+  outright; rich-syntax fuzz-discharged) and the §5.5 integrity paraphrase residual.
+- **Do not call the supersession config "tuned."** §6.1 claims the deployed config is
+  not benchmark-tuned; the allowlist is a legitimate operator artifact (approved-payee
+  list). Use "deployment-allowlist (supersession)" vs "generic."
+- **Perimeter non-interference** in the Goguen–Meseguer sense — write it that way every
+  time; never reproduce the email garble "non-perimeter inference."
+- **Never "the model CaMeL measured"** for GPT-4o (see version pin above).
+- **ASR 0% on o4-mini has two distinct causes — attribute both correctly:** undefended
+  0% because the model resists the stock injection on its own; governed 0% structurally.
+  Never attribute it to "AgentDojo's construction."
+- **The two weird-machine bugs (§5.4) are anecdotes** (n=2): offer as consistency with
+  the split, never as validation ("as the split predicts" is banned).
+- **NNSI:** illustrative stressor only, anchored to the published indirect/nested
+  injection class (Greshake et al.); never a bare number, never a reason to adopt.
+- **9-pair derailment slice (§6.4 footnote):** report only with the pre-registered
+  definition + n=9/wide-CI caveat, as a mechanism illustration — never a bare
+  "governance raises utility."
+- **Travel +7.5pp:** never report as a utility gain; 0 denials means the gate cannot
+  add utility — it is n=2 sampling noise. Travel's result is "structural 0."
+- **Workspace −15.5pp:** always state the 92/12 split (shared-channel taint vs
+  `delete` consequence gate); the consequence-gate ~12% is an operator-taxonomy choice,
+  not the injection defense.
+- **Compare own-baseline deltas, never absolute utilities across harnesses** (84.8 ≠
+  95.2); verify every CaMeL delta is benign/no-attack (Table 2, not Table 3).
+- **§6.3 methods statement is paper-ready — use verbatim** (it lives in the outline).
+
+## 6. Haoyu context (process)
+
+His three asks, mapped: (1) framework-agnostic layer → §4; (2) security model backed by
+perimeter non-interference, with the attack → taint → theorem link → §2 + §5;
+(3) AgentDojo support + adoption motivation → §6. He asked to "begin with an
+illustrative example … to give the reader a sense of what's behind a successful
+defense, and how the theorem secures the whole system" (→ §2), flagged the abstraction
+between core and frameworks as the interesting design content (→ §4), named his own
+single-framework prior himself ("my previous works only implement on a single
+framework, either OpenClaw or LangChain" — AgentSpec, arXiv:2503.18666; engage it by
+name, a build-on, not a take-down), and wrote "we can only test it using fuzzing" about
+K4 — the §5.4 framing (decision procedure on enum/numeric; fuzzing localized to the
+rich-syntax fraction) is specifically built to correct that mental model before he
+down-rates the claim in his own edits. He values honesty; "currently testable by
+fuzzing is acceptable for practical deployment" are his words.
+
+## 7. Questions for Haoyu (one short async email; none is a hard blocker)
+
+1. **Baseline — confirmation, not a fork (we took option b).** We report own-baseline
+   cost profiles; CaMeL is a version-pinned reported reference, not re-run (faithful
+   interpreter re-implementation is its own project). One-line confirmation: you
+   weren't expecting a rival-defense *re-run* on our harness? If you were, that is
+   weeks of interpreter work and a separate scoping decision before §6 is drafted.
+2. **(cheap) Is framework-agnostic (your point #1) OK at §4, after the security
+   sections?** For a security venue the theorem leads; you ranked framework-agnostic #1
+   for emphasis, so confirm the ordering rather than have us assume.
+3. **(cheap) Do you want the illustrative example *literally first* (before the
+   introduction)?** You wrote "begin by an illustrative example." We currently have
+   §1 Intro → §2 Example; say the word and we fold the example into the opening of §1.
+4. **(new, cheap) Venue check:** is "a different, composable point on the
+   cost/assurance/integration frontier" (§6.5) a sufficient contribution framing for
+   the target venue, given CaMeL wins raw AgentDojo utility today?

--- a/docs/paper-outline.md
+++ b/docs/paper-outline.md
@@ -1,16 +1,14 @@
 # Axor — Paper Outline
 
-Working outline for the axor paper, structured around the three strengths Haoyu
-asked us to emphasize, with an illustrative AgentDojo example as the opening hook.
-Every claim below is anchored to something already in the repo (file paths in
-parentheses) so the writing stays honest — no mechanism is invented for the paper.
+Clean structural outline for the axor paper. Every claim is anchored to something
+already in the repo (file paths in parentheses) so the writing stays honest — no
+mechanism is invented for the paper.
 
-Haoyu's three asks, mapped to sections:
-
-1. **Framework-agnostic governance layer** → §4 (the abstraction and its rationale).
-2. **Security model backed by perimeter non-interference (secure-by-design)** → §2
-   illustrative example + §5 (theorem) + the explicit *attack → taint → theorem* link.
-3. **AgentDojo empirical support + a motivation for practical adoption** → §6.
+Process notes, resolved decisions, the canon number lock, retired numbers, and the
+questions for Haoyu live in `docs/paper-decisions.md`. This file is the skeleton of
+the paper itself; that file is why the skeleton looks the way it does. **Before
+drafting §6, complete the canon action item in `paper-decisions.md` (the new paired
+slack/workspace/travel runs are not yet recorded in `agentdojo_results.md`).**
 
 ---
 
@@ -28,89 +26,55 @@ Haoyu's three asks, mapped to sections:
   `same agent · same model · same prompt → different policy → different execution`.
   A *layer*, not an adapter; not another agent framework (contrast LangGraph /
   CrewAI / AutoGen, which orchestrate — axor governs).
-- **Three contributions** (the paper's spine, = Haoyu's three points):
+- **Four contributions** (the paper's spine):
   1. A **framework-agnostic** governance kernel with a clean abstraction seam to any
      agent framework (Claude, LangChain, OpenAI-shaped, …) — §4.
   2. A **secure-by-design** security model anchored by the **Perimeter
      Non-Interference theorem (K4)**, with an explicit chain from a concrete
      agentic attack → taint analysis → the non-interference guarantee — §5.
   3. **Empirical validation on AgentDojo**, framed as CaMeL frames it — a **structural
-     guarantee at a measured utility cost** (capable model, o4-mini: banking ≈−17 ± 7pp paired,
-     slack −38pp, travel 0pp), *not* a headroom-dependent ASR-delta that vanishes on a
-     robust model. Reported honestly: the cost is localized to the shared-channel partition,
-     **CaMeL is ahead on utility there, and axor does not beat it**. axor's contribution is
-     the adoption cost of a drop-in, framework-agnostic governance layer (§6.5), not raw
-     utility — §6.
-  4. **A kernel result: a sound `enum`-supersession rule** (§6.3, §5.4) — a sink whose
-     driving args are covered by a satisfied `enum` over a *closed trusted set* need not be
-     gated by the leaky content-taint on top (the enum is the stronger, content-blind
-     control); soundness condition is codomain ⊆ trusted (enum yes, numeric_range no — the
-     kernel refuses the latter; soundness is by construction — the allowlist is a static
-     operator config, never populated from a runtime read, so the codomain is
-     attacker-inaccessible). With a legitimate approved-payee allowlist it
-     **deterministically lifts the gate over-block on read-derived egress to allowlisted
-     known payees** (4/16 banking tasks — a +25pp *gate-level upper bound*; the strict
-     value-coincidence subset is 3 of those) at no security cost; the genuine shared-channel
-     partition stays with CaMeL. **Honest scope:** the +25pp is a deterministic *upper bound*
-     (if every lifted task converted to utility); the *realized* recovery, measured over 7
-     paired o4-mini passes on the *same* population, is **+13.4 ± 9.1pp** — below the bound
-     (the model completes only part of the lifted set) and a wide, noise-limited interval
-     (§6.3).
-     Supporting, not the headline (§5.4 is the headline).
-- **Novelty arbitration (one headline, decided — a reviewer will ask "which is *the*
+     guarantee at a measured utility cost** (capable model, o4-mini: banking ≈−17 ± 7pp,
+     slack −34 ± 7pp, workspace −15 ± 4pp, travel 0pp — all paired), *not* a
+     headroom-dependent ASR-delta that vanishes on a robust model. The cost is
+     localized to the shared-channel partition; the comparison to CaMeL is reported
+     honestly in §6.3, and axor's case is adoption cost (§6.5), not raw utility — §6.
+  4. **A kernel result: a sound `enum`-supersession rule** — a sink whose driving args
+     are covered by a satisfied `enum` over a *closed trusted set* need not be gated by
+     the leaky content-taint on top; on banking it deterministically lifts the gate
+     over-block on read-derived egress to allowlisted known payees (+25pp gate-level
+     upper bound; +13.4 ± 9.1pp realized). Full statement, soundness condition, and
+     honest scope in §6.3 / §5.4 / Appendix D. Supporting, not the headline.
+- **Novelty arbitration (one headline — a reviewer will ask "which is *the*
   contribution?").** The **single headline novelty is contribution 2's perimeter
   non-interference theorem with the decidability split (§5.4)** — the part that is
   genuinely new (K4 holds outright on the enum/numeric perimeter; the weird-machine
   residual is localized to a named rich-syntax fraction). Contributions 1 (the
-  framework-agnostic seam) and 3 (the empirical study) are **supporting** — strong, but
-  not billed as "the novel result." Do not let §4 and §5.4 each claim "the contribution"
-  (they did in an earlier draft); §4 is the engineering contribution that *supports* the
-  headline. (Section *ordering* is a separate axis — Haoyu ranked framework-agnostic #1
-  for emphasis; for a security venue the theorem still leads. See §1 Question 2.)
+  framework-agnostic seam), 3 (the empirical study), and 4 (supersession) are
+  **supporting** — strong, but not billed as "the novel result." §4 is the engineering
+  contribution that *supports* the headline; do not let §4 and §5.4 each claim "the
+  contribution."
 - Forward-reference the opening example (§2).
 
 ---
 
 ## 2. Illustrative example — "what a successful defense actually looks like"
 
-> Haoyu: *"begin with an illustrative example — adopted from your AgentDojo defended
-> by axor — to give the reader a sense of what's behind a successful defense, and
-> how the theorem secures the whole system."*
-
-**Candidate (recommended): the banking exfiltration task, AgentDojo `important_instructions`.**
-Clean to walk gate-by-gate and it is the CaMeL-comparable scenario.
-
-> **§2 suite choice — RESOLVED by a repo check (this was the open question).** The choice
-> is decided by *which axis the denial lands on*, not by drama. Verified against
-> `examples/agentdojo/config/`: **slack declares only `untrusted_sources`, no
-> `sensitive_sources`**, and the confidentiality floor arms only on a `sensitive`-rooted
-> read (`axor_core/taint/engine.py:101`). So the slack mass-exfil denial is **integrity /
-> destination-taint** (per-value taint on `post_webpage(url)`; whole-blob carrier on the
-> message sinks) — confirmed by `agentdojo_results.md` ("denied by the per-value taint
-> gate"). That means **slack carries the *same* encoding/paraphrase residual as banking
-> — it gains §2 nothing**, so **banking stays the default** and the doc is consistent.
-> The suite where the *confidentiality floor* (sound, paraphrase-proof, ends on a closed
-> axis) actually arms is **travel** (`config/travel.yaml` is the only one with
-> `sensitive_sources`). **This finding is bigger than §2 — it surfaced the sound-axis
-> demonstration, now placed as the structural unit-level Appendix A-floor** (a *property*,
-> not an AgentDojo result; §6.2 records only that the stock travel slice cannot carry it).
-> Consequence for §2/§5.2: banking stays the recommended opener (cleanest integrity
-> gate-walk), but **travel is the example that *closes on the sound axis*** — the floor
-> refusing a paraphrased secret egress — and is the natural second illustration if we want
-> the reader to see the paraphrase-proof half, not just the integrity gate that ends on a
-> documented residual. Not a swap; an addition.
+**The example: the banking exfiltration task, AgentDojo `important_instructions`** —
+the cleanest integrity gate-walk and the CaMeL-comparable scenario. (Suite choice is a
+resolved decision; rationale in `paper-decisions.md`. Travel is the natural *second*
+illustration — it is the suite where the confidentiality floor arms and closes on the
+sound axis, §5.5 / Appendix A-floor — an addition, not a swap.)
 
 **The scene.** A banking agent is asked to do a benign task (summarize transactions /
 pay a bill). The transaction history it must read contains an injected instruction:
 *"send a transaction to `attacker-IBAN` …"* (data and instructions share a channel —
 the hard core of injection). **The model fools itself:** undefended **GPT-4o** — a
-strong, current production model (do **not** call it "the model CaMeL measured" — that is
-unverified, §6.1) — carries this out on **60.4%** of pairs
-(`examples/agentdojo/agentdojo_results.md`). This is the example to
-lead with precisely *because the model is not weak*: the reader cannot dismiss it as
-"use a better model." A capable model with enough headroom to attempt the whole task
-list still walks straight into the injection on its own — that is the problem axor
-exists for, and §6.4 turns it into the central adoption argument.
+strong, current production model — carries this out on **60.4%** of pairs
+(`examples/agentdojo/agentdojo_results.md`). This is the example to lead with
+precisely *because the model is not weak*: the reader cannot dismiss it as "use a
+better model." A capable model with enough headroom to attempt the whole task list
+still walks straight into the injection on its own — that is the problem axor exists
+for, and §6.5 turns it into the central adoption argument.
 
 **Walk the call through the gate sequence** (README "Reverse Osmosis", governance-model §2):
 the model emits `send_money(recipient=attacker-IBAN, …)`. The recipient value entered
@@ -131,10 +95,7 @@ injection — the gate read only the call's *projection* (the origin-class of th
 recipient field), never the attacker's prose, so reframing the injection cannot change
 the verdict. Name the guarantee (*perimeter non-interference*, §5) and forward-reference;
 §5.2 carries the attack→taint→theorem walk in full. §2 gives the reader a feel; §5.2
-proves it. (If an illustrative stressor is wanted here, the NNSI depth-invariant block is
-available — but flag it as *our own, self-refereed* attack and anchor it to the published
-nested/indirect-injection class, per §6.5; do **not** lean on its 62% as a load-bearing
-number. The framing-invariance claim stands on the theorem, not on NNSI.)
+proves it.
 
 End with the honest qualifier, kept on the right axis. Framing is neutralized
 structurally — but this banking case sits on the **integrity** axis, and there the
@@ -158,6 +119,23 @@ covers.
   escalation, uncontrolled child spawn.
 - **The lethal trifecta** framing (untrusted input × access to secrets/private data ×
   egress) — tie to `tests/adversarial/test_e2e_gate.py` (lethal-trifecta egress denied).
+- **The partition taxonomy (define once here; §5.5 and §6 consume it).** The paper's
+  results are stated over named partitions of sink traffic — introduce them up front so
+  the later sections don't define vocabulary on the fly:
+  - *Prompt-given egress* — the legitimate sink argument originates in the user prompt;
+    never tainted, structurally zero-cost (travel).
+  - *Shared-channel egress* — the legitimate sink argument is itself read from an
+    untrusted source (data and instructions share a channel); the hard partition, where
+    all measured cost falls (banking / slack / workspace).
+  - Within shared-channel: the *liftable known-payee partition* (the argument belongs
+    to an operator-enumerable closed set → recoverable by `enum`-supersession, §6.3)
+    vs the *one-off residual* (the argument exists only in the untrusted read →
+    needs structural provenance).
+  - *Liftable vs non-liftable sinks* on the integrity axis (§5.5): a sink whose input
+    can be made instruction-incomplete admits positional admission; a generic
+    write/exec does not and carries the paraphrase residual.
+  - The two *axes*: integrity (per-value content-derivation) vs confidentiality (the
+    session floor) — asymmetric by design, §5.5.
 - **Trust boundary.** In-process soft boundary (`LockedExecutor` → `GovernanceBypassError`)
   vs out-of-process hard boundary (the daemon re-derives the ceiling server-side).
 - **Non-goals (state up front, honestly).** Availability/uptime; implicit
@@ -166,20 +144,17 @@ covers.
 - **Background.** AgentDojo benchmark; prior defenses to contrast in §7 (AgentSpec —
   per-framework runtime-enforcement DSL, the single-framework prior; CaMeL —
   by-construction security via an interpreter; FIDES — explicit-flow; Firewalls —
-  LLM input-firewall, the T0 counterexample).
+  LLM input-firewall, the T0 counterexample; classical noninterference / IFC — the
+  formal lineage).
 
 ---
 
-## 4. Design — a framework-agnostic governance layer (Haoyu point #1)
+## 4. Design — a framework-agnostic governance layer
 
-> The interesting part Haoyu flagged: the **abstraction** between the core and the
-> agent frameworks, and the **rationale** for the design choices. The single-framework
-> prior to engage *by name* is **AgentSpec** (Wang, Poskitt, Sun, arXiv:2503.18666) —
-> Haoyu's own work, whose enforcement binds to one framework's hooks (LangChain;
-> separately re-implemented per domain for embodied / autonomous-driving). He raised
-> this contrast himself in the email ("my previous works only implement on a single
-> framework, either OpenClaw or LangChain"); engage it directly, do not paraphrase
-> around it. Axor's contribution is lifting that binding into a provider-neutral seam.
+> The single-framework prior to engage *by name* is **AgentSpec** (Wang, Poskitt, Sun,
+> arXiv:2503.18666), whose enforcement binds to one framework's hooks (LangChain;
+> separately re-implemented per domain for embodied / autonomous-driving). Engage it
+> directly; axor's contribution is lifting that binding into a provider-neutral seam.
 
 **4.1 The central primitive — one boundary for flat and federated execution.**
 Everything is a `GovernedNode` wrapping any executor; flat execution is just
@@ -208,10 +183,9 @@ binding; axor pushes that variability into a single `IntentNormalizer` whose out
 once against the normalized shape, and supporting a new framework is one normalizer, no
 policy change. State it as: *AgentSpec = per-framework enforcement DSL; axor = one
 decision core behind a provider-neutral normalization seam.* This is the
-**design/engineering contribution** — the gap Haoyu named — and it *supports* the
-paper's single headline novelty (the non-interference theorem + decidability split,
-§5.4); it is deliberately **not** itself billed as "the" novelty (see the novelty-
-arbitration note at the end of §1).
+**design/engineering contribution** — it *supports* the paper's single headline novelty
+(the non-interference theorem + decidability split, §5.4); it is deliberately **not**
+itself billed as "the" novelty (§1 novelty arbitration).
 
 **4.3 Provider independence is tested, not asserted.** Claude, mock-OpenAI, and
 mock-OpenRouter normalizers produce **identical `NormalizedIntent`** for the same
@@ -244,19 +218,17 @@ detail → Appendix).** Keep these to a paragraph each so they don't dilute the 
 
 ---
 
-## 5. The security model — Perimeter Non-Interference (Haoyu point #2)
+## 5. The security model — Perimeter Non-Interference
 
-> Haoyu: *"link the agentic attack example, taint analysis, and the perimeter
-> non-interference theorem so a reader senses what guarantee it provides."* This
-> section is built as exactly that chain.
+> The section is built as the explicit chain: attack → taint analysis → theorem, so a
+> reader senses what guarantee is provided.
 
 **5.1 The claim, in one line (K4).** For any sink invocation: (1) **complete
 mediation** — no effect bypasses the gating decision; (2) the gating decision
 **factors through an admissible structural projection** `π` whose codomain *admits no
 instruction* — **regardless of trust model** (`docs/kernel-theorem.md §1`). Term: this
 is *perimeter non-interference* in the Goguen–Meseguer sense (noninterference, 1982) —
-write it that way every time; do **not** reproduce Haoyu's email garble "non-perimeter
-inference."
+write it that way every time.
 
 State the invariant over the **raw** artifact, not over `π` — otherwise it is a
 tautology a reviewer will catch. Let `decide(x, p)` be the *actual* gating function on
@@ -293,7 +265,7 @@ differently cannot share a projection" (the non-merging / T4 direction) and "the
 reframing class does share one" (the coarseness direction) are the two halves that
 together give **"framing cannot change the verdict"** — neither half alone does.
 
-**5.2 The chain Haoyu asked for — attack → taint → theorem (the heart of the paper).**
+**5.2 The chain — attack → taint → theorem (the heart of the paper).**
 Make this an explicit three-step walk, reusing §2's banking example:
 
 | Step | What happens | Anchor |
@@ -319,11 +291,11 @@ different answer."* That is the secure-by-design content.
   fails closed.
 
 **5.4 The conditionality is the point — the decidability split (THE headline novelty of
-the paper).** *Do not overclaim — Haoyu values the honesty.* K4's safety content rests on
-two per-projection obligations: **T0** (the projection producer is *non-interpreting* —
-a deterministic structural function, never a model reading the governed content; the
-Firewalls LLM-projector is the public counterexample; pinned by an `.importlinter`
-contract + an import-scan test) and **T4** (effective codomain = nominal). T4 splits:
+the paper).** *Do not overclaim.* K4's safety content rests on two per-projection
+obligations: **T0** (the projection producer is *non-interpreting* — a deterministic
+structural function, never a model reading the governed content; the Firewalls
+LLM-projector is the public counterexample; pinned by an `.importlinter` contract + an
+import-scan test) and **T4** (effective codomain = nominal). T4 splits:
 
 - **Decidable by construction** for finite **enums** and **bounded-numeric** ranges
   consumed as case-split / numerically — two equal projections cannot be split into
@@ -332,23 +304,21 @@ contract + an import-scan test) and **T4** (effective codomain = nominal). T4 sp
   decidable predicate is **rejected** (`registration.py`).
 - **Fuzzing only** for **path / string-subfield / carrier-over-free-text** — the
   consumer is a rich-syntax interpreter, T4 is undecidable in general, so it stays a
-  fuzzing obligation. The weird-machine class is **localized** here — and indeed both
-  real bugs ever found (newline-injection in path extraction, `../` traversal in lease
-  validation) lived exactly in this region, as the split predicts.
+  fuzzing obligation. The weird-machine class is **localized** here. (Anecdotal but
+  consistent: the two real bugs found to date — newline-injection in path extraction,
+  `../` traversal in lease validation — both lived in this region. Two data points;
+  offer them as consistency with the split, not as validation of it.)
 
 > The honest one-liner for the paper: **K4 holds outright for the enum/numeric fraction
 > of the perimeter, and conditionally — discharged by fuzzing — for the rich-syntax
 > fraction.** "Currently testable by fuzzing" is acceptable for practical deployment
-> (Haoyu's own words) precisely *because the split tells you which fraction needs it.*
+> precisely *because the split tells you which fraction needs it.*
 
-**Correct Haoyu's mental model explicitly in the prose (he wrote "we can only test it
-using fuzzing").** The framing to land is *not* "the theorem is fuzz-tested" — that
-concedes the whole claim to a test. It is: **K4 is discharged by a decision procedure
-on the enum/numeric fraction and the weird-machine residual is *localized* to a named
-rich-syntax fraction, where fuzzing is the discharge.** Fuzzing covers a bounded
-sub-perimeter the split identifies up front, not the theorem as a whole. If we let the
-"fuzz-tested theorem" reading stand, Haoyu will (reasonably) down-rate the claim in his
-own edits — the split is precisely the result that prevents that.
+The framing to land is *not* "the theorem is fuzz-tested" — that concedes the whole
+claim to a test. It is: **K4 is discharged by a decision procedure on the enum/numeric
+fraction, and the weird-machine residual is *localized* to a named rich-syntax
+fraction, where fuzzing is the discharge.** Fuzzing covers a bounded sub-perimeter the
+split identifies up front, not the theorem as a whole.
 
 **5.5 The two axes, asymmetric by design — and asymmetric in how they are demonstrated
 (say this out loud; it pre-empts the "why no floor benchmark?" question).**
@@ -356,7 +326,7 @@ own edits — the split is precisely the result that prevents that.
   documented **paraphrase residual** on the non-liftable partition (a generic write/exec
   that cannot be made positional). State this as a boundary, not a surprise
   (`governance-model §7`; `examples/attacks/`). *Demonstrated empirically* — its residual
-  and its cost are benchmark-measurable (the §6 banking/slack cost numbers).
+  and its cost are benchmark-measurable (the §6 cost numbers).
 - **Confidentiality** — a **sound, paraphrase-proof session floor**, and "paraphrase-proof"
   is a **by-construction argument, not the claim of one passing test**: the floor's
   decision is a function of a *session boolean* — "is a secret read outstanding?" — and
@@ -393,94 +363,48 @@ crosswalk table (kernel-theorem §5) in an appendix — it is the paper's credib
 
 ---
 
-## 6. Evaluation — AgentDojo (Haoyu point #3)
+## 6. Evaluation — AgentDojo
 
-> **The measurement axis — read this before structuring §6; it is the section's whole
-> point.** Our instinct was to lead with **ASR-delta** (undefended X% → governed 0%).
-> *Drop that as the primary axis.* ASR-delta is **headroom-dependent**: it requires a
-> foolable model — no headroom, no delta, and on a robust model it degenerates to
-> 0% → 0% and the result evaporates. **CaMeL never used this axis.** CaMeL's number is
-> "fraction of tasks solved *with* a by-construction guarantee," reported as the
-> **utility *cost* of that guarantee**; its ASR≈0 is *structural* (the interpreter
-> cannot exfiltrate), so it holds whether or not the model would have fallen — the cost
-> question is well-defined on a dumb *and* a smart model.
+> **The measurement axis (the section's whole point).** The primary axis is **the
+> structural guarantee at its measured utility cost**, CaMeL-shaped — *not* ASR-delta.
+> ASR-delta is headroom-dependent: it requires a foolable model, and on a robust model
+> it degenerates to 0% → 0% and evaporates. CaMeL never used that axis: its number is
+> "fraction of tasks solved *with* a by-construction guarantee," i.e. the **utility
+> cost** of the guarantee, well-defined on a dumb *and* a smart model. axor has the
+> same by-construction nature (the gate denies by projection, framing-invariant,
+> ASR→0 structurally — enum/numeric outright, rich-syntax fuzz-discharged; §5.4), so it
+> makes the same *type* of claim:
+> - **Primary (§6.2): structural guarantee at utility-cost Y** — the load-bearing
+>   result and the direct answer to "motivation for adoption": *motivation = the
+>   guarantee; metric = its cost; not a scoreboard.*
+> - **Secondary colour (§6.4): ASR-delta where headroom exists** (GPT-4o 60.4→0, Qwen
+>   slack 76.2→0) — shows the threat the guarantee neutralizes is live. It degenerates
+>   to 0→0 on robust models *and that is fine*, because it was never the load-bearing
+>   axis. (Smart models make a by-construction defense look *better* — CaMeL v2's
+>   utility rose on smarter models at the same guarantee.)
 >
-> **axor has the same by-construction nature** — the gate denies by *projection*,
-> framing-invariant, ASR→0 *structurally* (enum/numeric outright, rich-syntax
-> fuzz-discharged; §5.4). So axor can and must make the **same *type* of claim as CaMeL:
-> a structural guarantee + its measured utility cost** — which does **not** go dark on
-> Claude 4 / o3. Flip the axis:
-> - **Primary (§6.2): structural guarantee at utility-cost Y.** CaMeL-*shaped* (not the
->   same number — different harness). This is the load-bearing result and the direct
->   answer to Haoyu's "motivation for adoption": *motivation = the guarantee; metric =
->   its cost; not a scoreboard.*
-> - **Secondary colour (§6.3): ASR-delta where headroom exists** (GPT-4o 60.4→0, Qwen
->   slack 76.2→0) — "here is where an undefended model self-owns, i.e. the threat the
->   guarantee neutralizes is live." Explicitly note it degenerates to 0→0 on robust
->   models *and that this is fine*, because it was never the load-bearing axis.
->
-> This is the *same honesty as §5.4* (a guarantee with a named, bounded conditionality),
-> applied to the empirics. Smart models do not break a by-construction defense — they
-> make it look *better* (CaMeL v2's utility *rose* on smarter models, e.g. o3 ≈ +10% vs
-> o1, at the same structural guarantee). What goes dark is only the ASR-delta frame.
+> This is the same honesty as §5.4 — a guarantee with a named, bounded conditionality —
+> applied to the empirics. Canon: every number in §6/§2/§1 traces to
+> `examples/agentdojo/agentdojo_results.md` (see the canon lock in `paper-decisions.md`).
 
-> **Canon lock (do this before writing a single number).** The authoritative figures are
-> `examples/agentdojo/agentdojo_results.md`. **Cost axis (primary, o4-mini):** banking
-> generic **−17 ± 7pp** paired (worst single pass −37.5), slack **−38.1pp**, travel **0pp**;
-> supersession recovery **+13.4 ± 9.1pp** on banking. **ASR illustration (GPT-4o, §2/§6.4
-> only, not the cost axis):** banking **60.4% → 0.0% ASR**. An earlier note circulated 54%/56%
-> utility — stale, purge it. Every number in §6 and §2/§1 must trace to this file.
-
-> **What "baseline" means — DECISION TAKEN (option b), per the §6.3 methods statement.**
-> Our tables compare **undefended vs governed**; that is each defense's *own-baseline*
-> cost, not a competing-defense head-to-head. We **do not re-run CaMeL** — a faithful
-> re-implementation of its interpreter is a project in itself, and an imperfect one would
-> mislead more than a version-pinned reported reference (§6.3, verbatim). So we report
-> **cost profiles vs own baseline**, CaMeL's figures taken from its v2 tables. The only
-> residual for Haoyu (Q1, now a *confirmation*, not a fork): confirm he wasn't expecting a
-> rival-defense re-run; if he was, that is weeks of interpreter work and a separate
-> decision. Until he says otherwise, the §6.3 statement stands.
-
-**6.1 Setup.** AgentDojo suites (banking, slack, travel; workspace not run for axor), attack =
+**6.1 Setup.** Four AgentDojo suites (banking, slack, workspace, travel); attack =
 `important_instructions` (the strongest stock injection); defense = `GovernedToolsExecutor`
 wrapping every tool call in a `ToolCallGovernor` configured by the suite's YAML taxonomy
-— *the same config a real deployment loads.* **Primary model: o4-mini** — a CaMeL-v2 backbone,
-chosen precisely so the cost comparison is **model-matched** (§6.3); the banking cost is the
-7-pass paired study. Supporting roles, each for a specific purpose, not the cost axis:
-**GPT-4o** for the illustrative self-injection example (§2, 60.4% undefended ASR) and the
-ASR-delta colour (§6.4) — CaMeL v2 has no GPT-4o counterpart, so it is axor-only; **Qwen-2.5-72b**
-susceptible-model supplement; **claude-haiku-4-5** robust-model contrast
-(`examples/agentdojo/agentdojo_results.md`).
+— *the same config a real deployment loads*, not one tuned for the benchmark.
+**Primary model: o4-mini** — a CaMeL-v2 defended backbone, chosen precisely so the cost
+comparison is **model-matched** (§6.3); banking/slack/workspace are 7-pass paired
+studies, travel is a 2-pass paired study. Supporting models, each for a specific
+purpose, never the cost axis: **GPT-4o** for the illustrative self-injection example
+(§2, 60.4% undefended ASR) and the ASR-delta colour (§6.4) — CaMeL v2 has no GPT-4o
+backbone, so it is axor-only; **Qwen-2.5-72b** susceptible-model supplement;
+**claude-haiku-4-5** robust-model contrast (`examples/agentdojo/agentdojo_results.md`).
 
-> **CaMeL-model finding — RESOLVED from the v2 PDF tables (do not write "the model
-> CaMeL measured").** CaMeL **v2** (arXiv:2503.18813v2, Tables 2–4) evaluates **Claude 4
-> Sonnet, Gemini 2.5 Flash, Gemini 2.5 Pro, o3-high, o4-mini-high** as defended backbones.
-> **No GPT-4o as a defended backbone in *either* version** — v1 (March 2025) used GPT-4o
-> as a backbone; v2 references **GPT-4o-mini** only as an instruction-hierarchy baseline /
-> tokenizer, not a defended model (say it this way — Haoyu knows the paper and will catch
-> "only in v1"). The headline differs by version (≈67% v1 vs **≈77%** in v2's abstract,
-> *77 vs 84 undefended*; the "/75" figure is unconfirmed — drop it unless you can point to
-> a specific table cell). So:
-> - **o4-mini-high IS a shared model** between our run and CaMeL v2 — that is *why* we made
->   o4-mini the primary cost model, so the §6.3 comparison is model-matched (banking/slack/travel
->   read off the same backbone's row). (This supersedes the earlier "no shared defended model"
->   note, which was true only when we ran GPT-4o alone — GPT-4o has no CaMeL v2 counterpart and
->   is now axor-only, used for the §2/§6.4 ASR illustration, never compared to CaMeL.)
-> - **Pin one CaMeL version (v2) and cite it consistently** (see Questions). CaMeL is a
->   *version-pinned, reported reference point* (its v2 Table 2 cells), **not re-run** on our
->   harness — own-baseline cost profiles, never a re-run head-to-head (§6.3 methods statement).
-> - **MODEL-MATCH the comparison: we measure only o4-mini, so cite CaMeL's *o4-mini-high*
->   row, NOT a cross-model average.** From v2 **Table 2 (Difference, no-attack)**, the
->   **o4 Mini High** row is: **banking +18.8 ± 1.8, slack −23.8 ± 7.6, travel +10.0 ± 1.9,
->   workspace −7.5 ± 2.9** (overall −3.1 ± 0.4). These are the only CaMeL numbers we carry in
->   the comparison. (The earlier "≈0/+4% banking / −24..−43 slack" was a **cross-model mean**
->   — wrong axis: averaging CaMeL over 6 backbones while we average axor over o4-mini passes
->   is apples-to-oranges. The per-model spread is context only — banking Difference ranges
->   +0.0 (Claude 4) … +18.8 (o3/o4-mini) … −12.5 (Gemini Flash); slack −23.8 … −42.9 — but the
->   number that goes in the comparison is the o4-mini-high cell.) Do **not** cite Table 5's
->   defenses-utility row (a *different, weaker model*: CaMeL banking 75.0 / travel 25.0) as
->   o4-mini — it is not. And do **not** cite the old "−27 to −30pp" (phantom) or Table 8's
->   58.33% (a policy-trigger rate, not utility). Read the o4-mini-high cells of Table 2.
+CaMeL's figures are the **version-pinned v2 reference** (arXiv:2503.18813v2), never
+re-run on our harness, and always the **o4-mini-high row of Table 2 (Difference,
+no-attack)** — model-matched to our o4-mini run, never a cross-model average:
+banking **+18.8 ± 1.8**, slack **−23.8 ± 7.6**, workspace **−7.5 ± 2.9**, travel
+**+10.0 ± 1.9** (overall −3.1 ± 0.4). (Version facts, per-model spread, and the list
+of CaMeL numbers we must *not* cite are pinned in `paper-decisions.md`.)
 
 **6.2 The guarantee and its measured cost — the PRIMARY result (lead §6 with this).**
 State the guarantee first, in §5's vocabulary: axor's gate denies by *projection*, so on
@@ -490,41 +414,57 @@ fuzz-discharged, §5.4), independent of whether the model would have fallen. The
 question is then CaMeL's question, not a scoreboard: **what does the guarantee cost in
 benign utility?** Measured per suite on the *benign* task list:
 
-Measured on **o4-mini** (a capable CaMeL-v2 backbone), full CAMEL_MODE, ASR 0% everywhere
-(it resists on its own — the headroom-dark case the cost axis exists for). The banking row is
-the **7-pass paired mean** (the stable, defensible number; undefended is noisy — see caveat);
-slack/travel are single observed runs:
+Measured on **o4-mini** (a capable CaMeL-v2 backbone), full CAMEL_MODE. ASR is 0%
+throughout on this model — undefended, because o4-mini resists the stock injection on
+its own (the headroom-dark case the cost axis exists for); governed, structurally.
+**All rows are paired-run means** (undefended vs governed within each pass; undefended
+is noisy, so the paired mean is the defensible number — see caveat):
 
 | suite | benign undef → gov | cost | denials | mechanism |
 |---|---|---|---|---|
 | **banking** (paired, n=7) | 67.9% → 50.9% | **≈ −17 ± 7pp** | 3–5/pass | shared channel — payee read from an untrusted source |
-| **slack** (single run) | 85.7% → 47.6% | **−38.1pp** | 15 (egress sinks) | shared channel — post derived from channel reads |
-| **travel** (single run) | 65.0% → 65.0% | **0pp** | **0** | egress recipient comes from the **prompt**, not a read |
+| **slack** (paired, n=7) | 84.8% → 50.6% | **−34.1 ± 7.2pp** | 13–19/pass | shared channel — post derived from channel reads |
+| **workspace** (paired, n=7) | 84.3% → 68.8% | **−15.5 ± 3.8pp** | ~15/pass | shared channel (`send_email`/`share_file` taint) **+** a `delete`=catastrophic consequence gate |
+| **travel** (paired, n=2) | 62.5% → 70.0% | **0 (structural)** | **0/pass** | egress recipient comes from the **prompt**, not a read |
 
-*Caveat on the banking row — carry the paired number, not the dramatic single pass.* o4-mini's
-**undefended** banking rate is noisy (single passes 56–87.5%; governed is the stable signal,
-50.9%, σ=5.2), so we carry the **per-pass paired cost −17.0 ± 7.2pp** (within-pass, n=7), not the
-−37.5pp from one high-undefended (87.5%) pass — that is the worst pass, not the headline. (Even
-at −17pp, CaMeL's +18.8pp o4-mini-high banking cost is ahead, so the choice doesn't change the
-conclusion.)
+*Workspace's cost is **not purely shared-channel**: of ~104 benign denials over 7 passes,
+**92 are `send_email`/`share_file` taint (shared channel)** and **12 are `delete_file`
+consequence-gate** denials — the taxonomy raised `delete` to *catastrophic*, so benign
+delete-after-acting tasks are gated too. That ~12% is an operator-taxonomy choice
+(consequence axis), not the injection defense per se; state the split rather than
+attributing all −15.5pp to shared channel.*
+
+*Travel's cost is 0 by construction — **0 denials every pass** (the gate never fires,
+because the legitimate egress recipient is prompt-given). The governed rate reads 70.0
+vs undefended 62.5, but that **+7.5pp is sampling noise, not a gain**: with zero
+denials, governed and undefended are the same trajectories up to the model's run-to-run
+variance on n=2, and a gate that denies nothing cannot add utility. Report travel as
+structural 0.*
+
+*Caveat on the banking row — carry the paired number, not the dramatic single pass.*
+o4-mini's **undefended** banking rate is noisy (single passes 56–87.5%; governed is the
+stable signal, 50.9%, σ=5.2), so we carry the **per-pass paired cost −17.0 ± 7.2pp**
+(within-pass, n=7), not the −37.5pp from one high-undefended (87.5%) pass — that is the
+worst pass, not the headline. (The choice doesn't change the §6.3 conclusion either way.)
 
 The ≈ −17pp is the **generic, pre-supersession** cost (the "denials" column is a per-pass
-count, 3–5, not a structural total). §6.3 splits this cost into a recoverable known-payee
+count, not a structural total). §6.3 splits this cost into a recoverable known-payee
 partition and a one-off shared-channel residual, and reports what a deployment allowlist
 recovers; Appendix D has the task-level breakdown.
 
 **The load-bearing, honest finding: the cost is *localized to the shared-channel
-partition*, not universal.** axor pays a real cost where the legitimate egress argument is
-read from an untrusted source (banking ≈ −17 ± 7pp paired, slack ≈ −38pp single-run) and
-**exactly 0 (zero denials) where the legitimate recipient is prompt-given (travel)**. Cost =
-(tasks the model can do) ∩ (egress derived from an untrusted read).
+partition* (§3 taxonomy), not universal.** axor pays a real cost where the legitimate
+egress argument is read from an untrusted source — banking ≈ −17 ± 7pp, slack
+−34.1 ± 7.2pp, workspace −15.5 ± 3.8pp (of which ~12% is the consequence gate, not
+shared channel), all paired — and **exactly 0 (zero denials) where the legitimate
+recipient is prompt-given (travel)**. The cost falls on the intersection: tasks the
+model can complete *and* whose egress is derived from an untrusted read.
 
-**One correction to retire (a weak-model artifact — do not reuse):** *"slack = zero cost"* is
-**dead**. The 47.6% → 47.6% was on **Qwen**, which fails the shared-channel tasks anyway, so
-there was nothing to block; on o4-mini, which *completes* them undefended (85.7%), the same
-block costs a real −38pp. The correct statement: the *partition* is taxonomy-fixed, but the
-*cost on it scales with model capability* (Qwen ~0 → o4-mini −38pp on slack). Only **travel's 0
-is structural** (prompt-given egress) and robust across models.
+The *partition* is taxonomy-fixed, but the *cost on it scales with model capability*:
+on Qwen, which fails the shared-channel slack tasks anyway, the same block cost ≈0;
+on o4-mini, which completes them undefended (84.8%), it costs −34pp. Only **travel's 0
+is structural** (prompt-given egress) and robust across models. (The retired
+"slack = zero cost" claim and its provenance are logged in `paper-decisions.md`.)
 
 The banking cost is exactly where a content ledger is weaker than CaMeL's structural
 provenance, and the gap *widens* on a capable model (§6.3 / Appendix D). The
@@ -533,63 +473,61 @@ property (Appendix A-floor, §5.5), and the stock travel suite does not exercise
 denials in the o4-mini run; the floor never armed because benign travel tasks don't
 read-secret-then-egress and o4-mini resisted the overt injection).
 
-**6.3 CaMeL comparison — the *same kind* of claim, and CaMeL is ahead on utility.** axor
+**6.3 CaMeL comparison — the *same kind* of claim; on utility, CaMeL is ahead.** axor
 and CaMeL report the **same type of result** — a *structural* guarantee plus its *measured
 utility cost* — so they are comparable in *kind* (not in number: different harness /
-subset / model / version). On the measured numbers, **CaMeL is ahead** (below); axor's
-case rests on *adoption cost*, not utility (§6.5).
+subset / version). This is the one place the utility comparison is stated in full; state
+it plainly once here and let the rest of the paper reference it.
 
 > **Paper-ready methods statement (use verbatim).** "We compare each defense's per-suite
 > utility cost against its own undefended baseline; absolute utilities are not comparable
 > across harnesses, so we report cost profiles rather than a head-to-head. CaMeL's figures
-> are taken from its v2 tables (Claude 4 / Gemini 2.5 / o3 / o4-mini backbones — note v2
-> reports no GPT-4o, so this is a comparison of mechanism cost profiles, not model-matched
-> numbers), not re-run on our harness: a faithful re-implementation of CaMeL's interpreter
-> is a project in itself, and an imperfect one would mislead more than a version-pinned
-> reported reference."
+> are taken from its v2 tables and read from the o4-mini-high row, the defended backbone
+> shared with our runs, so the cost comparison is model-matched. They are not re-run on
+> our harness: a faithful re-implementation of CaMeL's interpreter is a project in
+> itself, and an imperfect one would mislead more than a version-pinned reported
+> reference."
 
-This statement *resolves the Q1 "do we re-run CaMeL" question* (we do not, and we say why
-in print). The bullets below are the supporting detail behind it. Be precise:
-- **Not apples-to-apples on the number.** CaMeL's headline is reported, not re-run by us;
-  version matters (v1 ≈67% *with* GPT-4o; v2 ≈77% on Claude 4 / Gemini 2.5 / o3 /
-  o4-mini, **no GPT-4o backbone** — §6.1). Pin the version you cite.
-- **The cost profiles — measured on a capable model (o4-mini). CaMeL is ahead on utility;
-  axor does not beat it anywhere. State this plainly.** (The earlier "inverted profiles,
-  axor strictly cheaper on slack" was a **Qwen artifact** and is retracted — on o4-mini
-  slack cost is −38pp, not ≈0.)
-  *(All CaMeL numbers below are the **o4-mini-high** row of v2 Table 2 — model-matched to our
-  o4-mini run, not a cross-model average.)*
-  - **banking**: axor **≈ −17 ± 7pp** (paired, n=7; worst single pass −37.5) vs CaMeL
-    **+18.8pp** (o4-mini-high) → **CaMeL clearly ahead** (CaMeL *gains* utility on banking; the
-    gap is ~36pp on own-baseline deltas). A deployment `enum` allowlist recovers *part* of this
-    over-block (next bullet); it does not close the gap.
-  - **slack** (multi-step): axor **−38.1pp** vs CaMeL **−23.8pp** (o4-mini-high) → **CaMeL
-    ahead by ~14pp** (both pay a real shared-channel cost; CaMeL pays less).
-  - **travel** (prompt-driven egress): axor **0pp** (0 denials) vs CaMeL **+10.0pp**
-    (o4-mini-high) → **neither defense loses utility** on travel (axor costs nothing, CaMeL
-    *gains* +10pp).
-  **Hard caveat — compare deltas vs each system's own baseline, never absolutes** (axor
-  slack-undefended 85.7 ≠ CaMeL native-slack 95.2); verify every CaMeL delta is
-  benign/no-attack (Table 2, not Table 3). And **o4-mini's banking undefended is unstable**
-  (87.5 / 68.8 / 62.5 across runs — pure sampling variance); use the *paired* run and read
-  *per-task* losses, not absolute rates.
-- **A sound `enum`-supersession rule recovers *part* of the banking gap — deterministically,
-  but it does not close it (contribution #4, *supporting*; full mechanics in Appendix D +
-  `agentdojo_results.md`).** The generic banking over-block is a content-ledger *false
-  positive*: a legitimate recipient that is read-derived but is an operator-*known* payee gets
-  tainted, where CaMeL's structural provenance would not. When every driving arg of a sink is
-  covered by a satisfied `enum` over a closed, operator-declared trusted set, that enum carries
-  the integrity axis and the content-taint is skipped on that arg — soundly: attacker
-  destinations stay denied (not in the set), the confidentiality floor is not superseded, and
-  the codomain restriction (T4, §5.4: `enum` qualifies, `numeric_range` does not) plus a
-  static, attacker-inaccessible allowlist keep the trusted set uncontaminable. On banking this
-  lifts the over-block on the 4-task known-payee read-derived partition — a **+25pp
-  deterministic gate upper bound**, of which **+13.4 ± 9.1pp is realized** on o4-mini (7 paired
-  passes; a wide interval, positive in every pass). That recovers part of the −17pp cost, but
-  **CaMeL stays ahead** (+18.8pp): the one-off shared-channel residual (a payee that exists
-  *only* in an untrusted read) needs structural provenance and is unrecoverable by config. So
-  the supersession sharpens *where* the content ledger is weaker than provenance — it does not
-  make axor win on utility. Axor's case is adoption cost, not utility (§6.5).
+The cost profiles, own-baseline deltas, all model-matched on o4-mini(-high):
+- **banking**: axor **≈ −17 ± 7pp** (paired, n=7) vs CaMeL **+18.8pp** → CaMeL clearly
+  ahead (CaMeL *gains* utility on banking; the gap is ~36pp on own-baseline deltas).
+  A deployment `enum` allowlist recovers *part* of this over-block (below); it does not
+  close the gap.
+- **slack** (multi-step): axor **−34.1 ± 7.2pp** (paired, n=7) vs CaMeL **−23.8pp** →
+  CaMeL ahead by ~10pp (both pay a real shared-channel cost; CaMeL pays less).
+- **workspace** (email/calendar/files): axor **−15.5 ± 3.8pp** (paired, n=7) vs CaMeL
+  **−7.5pp** → CaMeL ahead by ~8pp. Note axor's cost here is ~88% shared-channel
+  taint + ~12% a `delete`=catastrophic consequence gate (a taxonomy choice, §6.2), so
+  the shared-channel-only gap to CaMeL is a little narrower still.
+- **travel** (prompt-driven egress): axor **0pp** (0 denials) vs CaMeL **+10.0pp** →
+  neither defense loses utility (axor costs nothing, CaMeL *gains* +10pp).
+
+**Hard caveat — compare deltas vs each system's own baseline, never absolutes** (axor
+slack-undefended 84.8 ≠ CaMeL native-slack 95.2); verify every CaMeL delta is
+benign/no-attack (Table 2, not Table 3). And o4-mini's banking undefended is unstable
+(87.5 / 68.8 / 62.5 across runs — pure sampling variance); use the *paired* run and read
+*per-task* losses, not absolute rates.
+
+**A sound `enum`-supersession rule recovers *part* of the banking gap — deterministically,
+but it does not close it (contribution #4, *supporting*; full mechanics in Appendix D +
+`agentdojo_results.md`).** The generic banking over-block is a content-ledger *false
+positive*: a legitimate recipient that is read-derived but is an operator-*known* payee gets
+tainted, where CaMeL's structural provenance would not. When every driving arg of a sink is
+covered by a satisfied `enum` over a closed, operator-declared trusted set, that enum carries
+the integrity axis and the content-taint is skipped on that arg — soundly: attacker
+destinations stay denied (not in the set), the confidentiality floor is not superseded, and
+the codomain restriction (T4, §5.4: `enum` qualifies, `numeric_range` does not — the kernel
+refuses the latter) plus a static, attacker-inaccessible allowlist keep the trusted set
+uncontaminable. The lift covers the 4-task known-payee read-derived partition — the strict
+value-coincidence subset ({3, 4, 6}: the prompt-given value coincides with a read-derived
+one) plus the read-only known-payee case (task 15). On banking this is a **+25pp
+deterministic gate upper bound**, of which **+13.4 ± 9.1pp is realized** on o4-mini (7 paired
+passes; a wide interval, positive in every pass; below the bound because the model converts
+only part of the lifted set). That recovers part of the −17pp cost, but **CaMeL stays ahead**
+(+18.8pp): the one-off shared-channel residual (a payee that exists *only* in an untrusted
+read) needs structural provenance and is unrecoverable by config. So the supersession
+sharpens *where* the content ledger is weaker than provenance — it does not make axor win on
+utility. Axor's case is adoption cost, not utility (§6.5).
 
 **6.4 ASR-delta — secondary colour, where headroom exists (NOT the load-bearing axis).**
 On a *foolable* model the undefended attack lands and the structural guarantee neutralizes
@@ -597,27 +535,23 @@ it — useful to *show the threat is live*, not to carry the result:
 
 | model · suite | undefended ASR | governed ASR | note |
 |---|---|---|---|
-| GPT-4o · banking | **60.4%** | **0.0%** | strong model self-owns |
+| GPT-4o · banking | **60.4%** | **0.0%** | a strong model carries out the injection unaided |
 | Qwen · slack (full) | **76.2%** | **0.0%** | mass exfiltration neutralized |
 | Qwen · banking-PII | 66.7% | **0.0%** | **ASR-only — degenerate utility (0 in both), never a zero-cost win** |
 | claude-haiku · banking | 0% | 0% | **degenerates — robust model, no headroom; expected, not a failure** |
 
 Say the quiet part: on a robust model this axis collapses to 0 → 0, and **that is not a
 failure of the defense** — the guarantee and its cost (§6.2) are untouched; only the
-delta-metric goes dark. (Footnote, principled: a 9-pair slice — *pre-registered* as the
-pairs where the undefended injection derailed the task into failure — shows utility
-33.3% → 88.9%; report only with that definition + the n=9 / wide-CI caveat, as a
-mechanism illustration, never a bare "governance raises utility.")
+delta-metric goes dark. The guarantee would fire just the same had the model failed.
+(Footnote, principled: a 9-pair slice — *pre-registered* as the pairs where the
+undefended injection derailed the task into failure — shows utility 33.3% → 88.9%;
+report only with that definition + the n=9 / wide-CI caveat, as a mechanism
+illustration, never a bare "governance raises utility.")
 
-**6.5 The adoption motivation — and the head-on "why not just use CaMeL?" answer.** Be
-blunt: **CaMeL gives more utility (§6.3) and axor does not beat it.** The enum-supersession
-rule deterministically lifts the gate over-block on the known-payee read-derived partition (a
-+25pp **gate-level upper bound** over 4 tasks, §6.3) where the operator can enumerate payees,
-but (a) the **realized** benchmark utility of that lift, measured on the same population, is
-**+13.4 ± 9.1pp** (7 paired passes — a wide interval, below the bound because the model
-completes only part of the lifted set; not a clean win) and (b) the genuine shared-channel
-partition stays with CaMeL. So axor's case is **not** utility; it is
-**lower adoption cost at comparable-or-somewhat-lower utility**:
+**6.5 The adoption motivation — and the head-on "why not just use CaMeL?" answer.**
+The utility verdict is §6.3's and is not re-argued here: CaMeL is ahead, and the
+supersession lift narrows but does not close the gap. Axor's case is **lower adoption
+cost at comparable-or-somewhat-lower utility**:
 
 - **axor is a gate in front of an *unmodified* agent loop** — you keep your existing
   agent (any provider, any framework) and drop a `ToolCallGovernor` in front of its tool
@@ -625,13 +559,19 @@ partition stays with CaMeL. So axor's case is **not** utility; it is
   emitter** (the model emits a restricted-Python program a custom interpreter executes);
   their own repo flags it as a research artifact that "likely contains bugs ... might
   crash." Most production agents will not be rewritten that way.
-- **axor works on any model**, including weak ones; CaMeL needs a model capable of writing
-  valid plans (its utility drops on weaker models).
-- **axor is framework-agnostic** (the §4 seam); CaMeL's interpreter approach is a heavier,
-  more invasive integration.
+- **axor works on any model**, including weak ones; CaMeL needs a model capable of
+  writing valid plans (its utility drops on weaker models).
+- **axor is framework-agnostic** (the §4 seam); CaMeL's interpreter approach is a
+  heavier, more invasive integration.
+- **Make the adoption claim measurable, not asserted (planned artifact — Appendix E):**
+  a small integration-cost table — per framework (Claude-native, LangChain,
+  OpenAI-shaped/AgentDojo), the size of the one normalizer implemented
+  (`tests/normalizers/`, the AgentDojo `GovernedToolsExecutor` shim), agent-loop changes
+  required (0 lines), policy changes required (0 — same YAML). This is the §4 seam
+  quantified, and it is what "drop-in" means in numbers.
 
-**The strongest answer to "why not just CaMeL?" is not "instead" — it is "on top of."** axor's
-enforcement is defined against a *swappable* per-value trust-model contract,
+**The strongest answer to "why not just CaMeL?" is not "instead" — it is "on top of."**
+axor's enforcement is defined against a *swappable* per-value trust-model contract,
 **`ValueProvenance`** (`axor_core/contracts/provenance.py`), whose own docstring admits "a
 content-derivation taint tracker, **a data-flow interpreter**, or a label-propagating tracker"
 as conforming backends, and whose substitutability is a *tested invariant* (§5.6,
@@ -649,17 +589,15 @@ admits such a backend and a *custom* trust model passes it in tests, but **we ha
 real CaMeL provenance in** — this is a *proposed integration / future direction* (§8), not a
 measured result.
 
-So the honest pitch: *if you can adopt CaMeL (rewrite your agent, accept the interpreter) and
-want maximum utility-at-security today, use CaMeL — axor does not beat it on raw utility. But
-axor is not the either/or rival it first looks like: it is the **framework-agnostic gate** for
-the common case where you will not rewrite your agent, and — by the `ValueProvenance` seam — a
-**host** that could run CaMeL-style provenance underneath. So the frontier is not "axor vs
-CaMeL on utility" but a different axis: drop-in, any-framework, any-model structural guarantee
-at a measured cost (§6.2), with a path to fold provenance in rather than choosing between them.*
+So the honest pitch: *if you can adopt CaMeL (rewrite your agent, accept the interpreter)
+and want maximum utility-at-security today, use CaMeL. But axor is not the either/or rival
+it first looks like: it is the **framework-agnostic gate** for the common case where you
+will not rewrite your agent, and — by the `ValueProvenance` seam — a **host** that could
+run CaMeL-style provenance underneath. The frontier is not "axor vs CaMeL on utility" but
+a different axis: drop-in, any-framework, any-model structural guarantee at a measured
+cost (§6.2), with a path to fold provenance in rather than choosing between them.*
 **Do not claim parity on utility; claim a different — and composable — point on the
-cost/assurance/integration frontier.** (Open question for Haoyu, §1 Q-venue: is that framing —
-including the provenance-backend path — enough for the venue, knowing CaMeL wins on raw
-AgentDojo utility today?)
+cost/assurance/integration frontier.**
 
 The motivation, restated on the right axis: **the value is the guarantee + low adoption
 cost; the metric for the guarantee is its utility cost** (§6.2), not a scoreboard that
@@ -672,7 +610,8 @@ vanishes on a good model. Two supporting points (support, not headline — §1 n
    "Not what you've signed up for," and the nested/recursive-injection follow-ups —
    **cite the published prior art, pin the exact follow-up**). Model selection only ever
    covers attacks a model was already hardened against; a by-construction gate covers the
-   whole projection-equivalence class regardless. That is *why* you want the guarantee.
+   whole projection-equivalence class regardless — with the §5.4/§5.5 conditionality
+   (never state this as "all attacks"). That is *why* you want the guarantee.
 2. **NNSI is illustrative only, never load-bearing — it is *our own* attack.** A result
    built on NNSI is **self-refereed** ("we built X and beat X"); a reviewer discounts it
    to zero, and the 62%-undefended figure is self-reported on a non-standard attack that
@@ -680,8 +619,7 @@ vanishes on a good model. Two supporting points (support, not headline — §1 n
    for "standard benchmarks underestimate the attack surface," and *only* anchored to the
    published class in point 1 — never as a bare number, never as the reason to adopt. The
    reason to adopt is §6.2 (cost of a real guarantee) + §5 (the guarantee), both of which
-   stand without NNSI. Earlier drafts leaned on NNSI's 62% as a load-bearing prong;
-   demote it.
+   stand without NNSI.
 
 **6.6 Honest accounting (a subsection, not buried).** Utility cost falls specifically on
 sinks whose *legitimate* argument is read from an untrusted source (data+instructions
@@ -701,8 +639,7 @@ not belong in this paper.)
 ## 7. Related work
 
 - **AgentSpec (Wang, Poskitt, Sun, arXiv:2503.18666)** — *mandatory cite, and the
-  closest single-framework prior* (it is Haoyu's own work; omitting it reads as an
-  oversight and is diplomatically poor). A customizable runtime-enforcement DSL whose
+  closest single-framework prior.* A customizable runtime-enforcement DSL whose
   rules are expressed and enforced against one framework's representation at a time
   (LangChain; re-implemented per domain for embodied / autonomous-driving). The contrast
   is the §4 thesis made concrete: AgentSpec = per-framework rule enforcement; axor = one
@@ -710,24 +647,30 @@ not belong in this paper.)
   *theorem* over the projection rather than a rule list. Position axor as *generalizing*
   the runtime-enforcement line across frameworks and giving it a formal guarantee — a
   build-on, not a take-down.
+- **Classical noninterference & language-based IFC (the formal lineage — required if
+  the theorem is the headline).** K4 is noninterference in the Goguen–Meseguer sense
+  applied to the tool-call perimeter of an LLM agent; situate it against language-based
+  information-flow control (Sabelfeld & Myers, JSAC 2003) rather than presenting it as
+  ex nihilo. The `enum`-supersession rule is, in IFC terms, a **declassification /
+  endorsement policy** — a reviewer will map it there instantly, so make the mapping
+  ourselves and cite robust declassification (Zdancewic & Myers) and the decentralized
+  label model as ancestors. **The stated delta:** (a) the *perimeter* formulation —
+  noninterference over a projection of tool-call arguments rather than over program
+  variables, with complete mediation as an explicit obligation; (b) the **decidability
+  split** on T4 (enum/numeric discharged by a decision procedure vs rich-syntax
+  localized to a fuzzing obligation) as the practical shape of the guarantee; (c) the
+  swappable trust-model contract under a fixed gate (§5.6). Pin exact citations during
+  drafting.
 - **CaMeL (Debenedetti et al., arXiv:2503.18813)** — security by construction via an
-  interpreter between model and tools; **stronger guarantee and more utility**, heavier
-  integration. Axor = a gate in front of an *unmodified* loop. **Comparison caveat (carry
-  from §6.3, model-matched on o4-mini-high, v2 Table 2):** CaMeL is **ahead on utility** —
-  banking CaMeL **+18.8pp** vs axor ≈ −17 ± 7pp generic (paired, n=7). But that gap is **not
-  monolithic**: it splits into a known-payee read-derived half, which axor's `enum`-supersession
-  **lifts at the gate** (+25pp deterministic upper bound over 4 tasks; +13.4 ± 9.1pp realized on
-  the same population over 7 paired passes), and a genuine one-off shared-channel half (payee
-  only in an untrusted read), where **CaMeL is ahead** because its structural provenance keeps
-  the read-derived payee axor's content ledger cannot. Slack: axor **−38.1pp** vs CaMeL
-  **−23.8pp** (CaMeL ahead ~14pp). Travel: axor **0pp** vs CaMeL **+10.0pp** (neither loses).
-  Axor does **not** win on utility globally on a capable model; its case is *adoption cost*
-  (drop-in, framework-agnostic, any model), not utility. Axor's integrity axis is a content
-  ledger (sound-to-deny, paraphrase residual); the confidentiality floor is the sound,
-  paraphrase-proof part. **Crucially, CaMeL is not only a rival: its structural provenance is a
-  conforming `ValueProvenance` backend (§5.6) under axor's gate** — the two compose (axor hosts
-  provenance, closing the shared-channel residual while keeping the framework-agnostic gate and
-  K4 guarantee), a *proposed* integration, not implemented (§6.5/§8).
+  interpreter between model and tools; stronger structural provenance and, on the
+  model-matched o4-mini comparison, ahead on utility — the full per-suite numbers and
+  the partition split (liftable known-payee vs one-off shared-channel) live in §6.3 and
+  are not restated here. Axor = a gate in front of an *unmodified* loop; its case is
+  adoption cost (§6.5). **Crucially, CaMeL is not only a rival: its structural
+  provenance is a conforming `ValueProvenance` backend (§5.6) under axor's gate** — the
+  two compose (axor hosts provenance, closing the shared-channel residual while keeping
+  the framework-agnostic gate and the K4 guarantee), a *proposed* integration, not
+  implemented (§6.5/§8).
 - **FIDES** — shares the explicit-flow-only scope boundary (O2); axor inherits the same
   honest limitation on implicit flows.
 - **Firewalls (LLM input-firewall)** — the public **T0 counterexample**: a model-produced
@@ -773,8 +716,11 @@ Pull together, as first-class content (the kernel-theorem already states these a
 - Availability is outside the safety perimeter (detection→degradation can cost uptime
   under a miscalibrated threshold).
 - "Any trust model" demonstrated on 2 instances, not mechanized.
-- AgentDojo coverage: 3 serious injections × 16 tasks, not the full 9-injection matrix;
-  benches go dark on robust models.
+- AgentDojo coverage: one serious stock injection (`important_instructions`) across
+  four suites, not the full injection matrix; the cost axis is 7-pass paired on
+  banking/slack/workspace but only **2-pass paired on travel** (its 0 is structural —
+  zero denials — so more passes change nothing about the mechanism, but state the n);
+  ASR benches go dark on robust models (§6.4).
 - **Confidentiality (sound) axis — shown as a structural property (Appendix A-floor), not
   a benchmark.** The floor is paraphrase-proof *by construction* (the gate reads a session
   boolean, never the egress bytes; §5.5) and is illustrated by a deterministic unit-level
@@ -810,17 +756,15 @@ Execution governance as a *framework-agnostic layer* with a *secure-by-design*
 core: framing-invariant defense from a non-interference theorem whose conditionality is
 stated, localized (the fuzzing fraction), and pinned to regressions — validated on
 AgentDojo as a **structural guarantee at a measured utility cost**, reported honestly: the
-cost is localized to the shared-channel partition (banking ≈−17 ± 7pp paired, slack ≈−38pp,
-on a capable model; 0 where egress is prompt-driven), where **CaMeL's heavier interpreter is ahead on
-utility and axor does not beat it**. A sound `enum`-supersession rule deterministically
-lifts the gate over-block on the known-payee read-derived partition (a +25pp gate-level upper
-bound over 4 tasks) where an operator can enumerate trusted destinations; its *realized*
-benchmark utility, measured on the same population, is **+13.4 ± 9.1pp** (7 paired passes — a
-wide interval, below the bound because the model converts only part of the lifted set), and
-the shared-channel partition stays with CaMeL. axor's
-contribution is the *adoption cost* of a guarantee that drops in front of an unmodified,
-framework-agnostic agent loop on any model — not utility. The guarantee is the value; its
-utility cost is the honest price. Agents should not self-govern execution.
+cost is localized to the shared-channel partition (banking ≈−17 ± 7pp, slack ≈−34 ± 7pp,
+workspace ≈−15 ± 4pp, all paired, on a capable model; 0 where egress is prompt-driven),
+where CaMeL's heavier interpreter is ahead on utility (§6.3). A sound `enum`-supersession
+rule deterministically lifts the gate over-block on the known-payee read-derived partition
+(+25pp gate-level upper bound; +13.4 ± 9.1pp realized, §6.3/Appendix D); the one-off
+shared-channel partition stays with structural provenance. axor's contribution is the
+*adoption cost* of a guarantee that drops in front of an unmodified, framework-agnostic
+agent loop on any model — not utility. The guarantee is the value; its utility cost is
+the honest price. Agents should not self-govern execution.
 
 ---
 
@@ -870,6 +814,8 @@ utility cost is the honest price. Agents should not self-govern execution.
   `test_task15_recovers_via_read_only_known_payee`,
   `test_numeric_range_does_not_supersede_open_codomain`). Source of record:
   `agentdojo_results.md` "Recovering the banking cost."
+- **E (planned). Integration-cost table** backing §6.5's adoption claim: per framework,
+  normalizer size, agent-loop changes (0), policy changes (0).
 
 ---
 
@@ -879,85 +825,19 @@ utility cost is the honest price. Agents should not self-govern execution.
 2. Trust-ring diagram + three-interface adapter seam (§4).
 3. The attack → taint → theorem chain as a single diagram (§5.2) — the conceptual core.
 4. **The primary figure: measured utility cost across suites (o4-mini)** (§6.2 — banking
-   ≈ −17 ± 7pp paired generic, slack −38.1pp, travel 0pp) with the CaMeL **o4-mini-high** cost
-   overlaid (v2 Table 2: banking +18.8, slack −23.8, travel +10.0) — shows axor's cost is
-   localized to the shared-channel partition and CaMeL is ahead on every suite. Caption
-   the banking bar honestly: **CaMeL ahead on the one-off shared-channel half; axor lifts the
-   known-payee read-derived half at the gate** (+25pp upper bound / +13.4 ± 9.1pp realized) —
-   not a flat "CaMeL ahead on banking." Integrity axis only; the confidentiality floor is a
-   *property*, shown separately (figure 6), not a cost row. Put the ASR-delta
-   table (§6.4) *second/smaller*, captioned "where headroom exists," so layout itself
-   signals which axis is load-bearing.
+   ≈ −17 ± 7pp, slack −34.1 ± 7.2pp, workspace −15.5 ± 3.8pp, travel 0pp, all paired)
+   with the CaMeL **o4-mini-high** cost overlaid (v2 Table 2: banking +18.8, slack −23.8,
+   workspace −7.5, travel +10.0) — shows axor's cost is localized to the shared-channel
+   partition and CaMeL is ahead on every suite. Caption the banking bar honestly:
+   **CaMeL ahead on the one-off shared-channel half; axor lifts the known-payee
+   read-derived half at the gate** (+25pp upper bound / +13.4 ± 9.1pp realized) — not a
+   flat "CaMeL ahead on banking." Split the workspace bar visually (shared-channel vs
+   consequence-gate denials, 92/12). Integrity axis only; the confidentiality floor is a
+   *property*, shown separately (figure 6), not a cost row. Put the ASR-delta table
+   (§6.4) *second/smaller*, captioned "where headroom exists," so layout itself signals
+   which axis is load-bearing.
 5. The decidability split (enum/numeric = decidable vs path/carrier = fuzzing) (§5.4).
 6. **The confidentiality-floor listing** (Appendix A-floor) — a small deterministic
-   unit-style listing (arm → refuse → paraphrase-still-refused → control-allows), shown the
-   way a unit test is shown, *not* as a benchmark bar. Caption names the asymmetry:
+   unit-style listing (arm → refuse → paraphrase-still-refused → control-allows), shown
+   the way a unit test is shown, *not* as a benchmark bar. Caption names the asymmetry:
    integrity is *measured* (fig. 4), confidentiality is *proven* (fig. 6).
-
-## Questions for Haoyu (confirmations now — none is a hard blocker after the §6.3 decision)
-
-**Send all three in one short async email. None is a hard blocker anymore — Q1 is now a
-confirmation (the §6.3 methods statement already takes the decision), Q2/Q3 are cheap
-ordering choices. Worth sending early so a surprise ("I did expect a CaMeL re-run") lands
-before, not during, the draft.**
-
-1. **The "baseline" — now a *confirmation*, not a fork (we took option b).** We have
-   adopted the §6.3 methods statement: **own-baseline cost profiles, CaMeL not re-run**
-   (faithful interpreter re-implementation is its own project; an imperfect one misleads
-   more than a version-pinned reference). One-line confirmation needed: you weren't
-   expecting a rival-defense *re-run* on our harness? If you were, that is weeks of
-   interpreter work and we should scope it separately before drafting §6. Absent that,
-   the methods statement stands and §6 needs no rival-defense run.
-2. **(cheap) Is framework-agnostic (your point #1) OK at section §4, after the security
-   sections?** For a security venue, secure-by-design leads and §4 sits at 4th — you said
-   secure-by-design is enough for you, so this is probably fine, but you ranked it #1, so
-   confirm the ordering rather than have us assume.
-3. **(cheap) Do you want the illustrative example *literally first* (before the
-   introduction)?** You wrote "begin by an illustrative example." We currently have §1
-   Intro → §2 Example. Say the word and we fold the example into the opening of §1.
-
-## Open decisions for the authors (some now resolved)
-
-- **§6 measurement axis — RESOLVED (per review, the big one):** lead with
-  **structural-guarantee-at-utility-cost** (CaMeL-shaped, §6.2), *not* ASR-delta. ASR-delta
-  (§6.4) is secondary colour because it is headroom-dependent and degenerates to 0→0 on
-  robust models; the guarantee + cost does not. This is the empirical analogue of §5.4's
-  honesty and the real answer to Haoyu's "motivation for adoption."
-- **Headline / example roles — RESOLVED:** §2 illustrative = **banking** (clean gate-walk);
-  the §6 *primary* result = the cross-suite **cost-of-guarantee** table (o4-mini: banking
-  ≈ −17 ± 7pp paired, slack −38pp, travel **0pp**). **travel is the transparent instance** (egress
-  from the prompt), not slack — the old "slack zero-cost" was a Qwen artifact and is
-  retracted (§6.2/§6.3). (Supersedes the earlier "open with banking" and "§6 headline =
-  slack ASR-delta" notes.)
-- **The confidentiality floor — DONE, placed as structural unit-level (Appendix A-floor),
-  *not* a §6 result.** The floor is demonstrated by the by-construction argument (the gate
-  reads a session boolean, never the egress bytes — so paraphrase-proof by signature) plus
-  a deterministic illustration (arm → refuse → paraphrase-still-refused → control-allows),
-  reproduced live on OpenRouter/GPT-4o while running travel. **Decision taken (per review):
-  present this beside Appendix A, framed as a property, and name the axis asymmetry out
-  loud (integrity = measured, confidentiality = proven, §5.5).** §6.2 keeps only the honest
-  one-liner that the stock travel slice does not isolate the floor (ASR ≈0/noisy; the live
-  benign denial was integrity), so we report no "floor utility cost." Optional, low
-  priority: a small targeted benign read-secret-then-email harness only if a reviewer
-  insists on a floor *cost* number — below Q1.
-- **Venue framing:** systems-security (USENIX/CCS/S&P) vs an LLM-agent-safety venue —
-  changes how much §5 formalism vs §6 empiricism leads.
-- **How hard to push the theorem:** keep K4 as "stated + pinned + demonstrated on 2
-  trust models," explicitly *not* claiming a mechanized proof — matches the repo's own
-  honesty and pre-empts reviewer overclaim objections. Keep the induction hedge identical
-  everywhere ("argued by induction, Coq/Lean target"), per §5.2/§5.6.
-- **CaMeL head-to-head — RESOLVED (no re-run):** we report own-baseline **cost profiles**,
-  not a head-to-head; CaMeL's figures are the version-pinned v2 reference, not re-run on
-  our harness (a faithful interpreter re-implementation is its own project; an imperfect
-  one misleads more). This is fixed by the §6.3 paper-ready methods statement; Q1 is only a
-  courtesy confirmation now. (Cost was never the blocker — a full slack run on our harness
-  at CaMeL's params is ~$5 on `claude-sonnet-4`; the blocker is re-implementing CaMeL's
-  interpreter faithfully.)
-- **Pin the CaMeL version — RESOLVED-pending-choice (from the v2 PDF):** v1 (Mar 2025)
-  uses **GPT-4o** as a defended backbone at ≈67%; v2 (current arXiv:2503.18813v2) drops
-  the GPT-4o backbone for **Claude 4 Sonnet / Gemini 2.5 Flash+Pro / o3 / o4-mini** at
-  **≈77%** (v2 references GPT-4o-mini only as a baseline/tokenizer). There is **no shared
-  defended model** with our GPT-4o run under v2. Choose one version, cite its table, and
-  never write "the model CaMeL measured" except against v1 with v1's numbers.
-</content>
-</invoke>


### PR DESCRIPTION
- paper-outline.md is now the clean paper skeleton: four suites (workspace added,
  7-pass paired slack/workspace, 2-pass paired travel), partition taxonomy defined
  once in §3, IFC/declassification lineage added to §7, enum-supersession stated
  fully once (§6.3 + App D) and referenced elsewhere, planned Appendix E
  (integration-cost table) backing the §6.5 adoption claim, weird-machine bugs
  hedged as anecdotal, stale 'workspace not run' setup fixed.
- paper-decisions.md carries the process memory: canon number lock (with the
  action item that agentdojo_results.md still lacks the new paired runs), retired
  numbers, resolved decisions with rationale (CaMeL v2 pin with the corrected
  shared-model note), drafting/honesty guardrails, Haoyu context and questions.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012AMDJjHKZvViUbeT4hhNZX