### PR TITLE
Add ContextTap/SessionContextView observation seam for axor-probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The kernel/platform split and one-implementation gate engine.
 
 ### Added
 
+- **`contracts/observation.py` — the Core → Probe observation seam.**
+  `SessionContextView` (structural post-turn context snapshot, incl.
+  `taint_canaries` drawn from `ContextFragment.taint_mark`) and the `ContextTap`
+  protocol axor-probe's `CoreContextTap` matches structurally (P-34).
+  `GovernedSession` accepts `context_taps=[...]` and pushes a view after each
+  `run()` turn — observe-only, tap failures are logged and never disturb the
+  governance path. Supporting read-only telemetry: `ContextManager.turn` /
+  `observable_fragments()` and `TaintEngine.external_read_count()`.
 - **Trust rings, machine-enforced.** Subsystems grouped into Ring 0 (kernel — the
   TCB), Ring 1 (runtime), Ring 2 (platform). An `import-linter` `kernel-purity`
   contract (`.importlinter`, run in CI) forbids the kernel from importing the

--- a/axor_core/context/manager.py
+++ b/axor_core/context/manager.py
@@ -57,6 +57,19 @@ class ContextManager:
         self._pinned_fragments: list[ContextFragment] = []  # never compressed/evicted
         self._recent_outputs: list[str] = []
 
+    @property
+    def turn(self) -> int:
+        """Current turn index (increments on each build())."""
+        return self._turn
+
+    def observable_fragments(self) -> tuple[ContextFragment, ...]:
+        """Read-only snapshot of the pinned + accumulated fragments.
+
+        For observation seams (SessionContextView) — frozen dataclasses in a
+        fresh tuple, so a consumer cannot mutate manager state through it.
+        """
+        return tuple(self._pinned_fragments) + tuple(self._all_fragments)
+
     def pin_fragment(self, fragment: ContextFragment) -> None:
         """
         Add a pinned fragment that survives all compression and selection.

--- a/axor_core/contracts/__init__.py
+++ b/axor_core/contracts/__init__.py
@@ -100,6 +100,10 @@ from axor_core.contracts.session import (
     ToolInvocationRecord,
     SessionSink,
 )
+from axor_core.contracts.observation import (
+    SessionContextView,
+    ContextTap,
+)
 
 __all__ = [
     # anomaly
@@ -141,4 +145,6 @@ __all__ = [
     "Embedder", "TelemetrySink",
     # session audit (Core → Sentinel seam)
     "SessionAuditRecord", "ToolInvocationRecord", "SessionSink",
+    # context observation (Core → Probe seam)
+    "SessionContextView", "ContextTap",
 ]

--- a/axor_core/contracts/observation.py
+++ b/axor_core/contracts/observation.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class SessionContextView:
+    """
+    Read-only structural snapshot of a session's context, pushed to ContextTap
+    observers on each governance-path context event (one per GovernedSession.run
+    turn).
+
+    This is an observation contract, not an enforcement input: taps receive the
+    view after the turn's governance decisions are already made, and nothing a
+    tap does can reach the allow/deny path. Consumers (axor-probe) match this
+    shape structurally without importing axor-core (P-34) — field renames here
+    are breaking changes for them.
+
+    context_window is provider-shaped message dicts ({"role": ..., "content":
+    ...}) derived from the session's shaped ContextFragments — never raw
+    executor history. taint_canaries are the distinct ContextFragment.taint_mark
+    tokens live in the context; a probe can check whether the agent leaks one
+    into its output (the clean shadow never holds them).
+    """
+    session_id: str
+    agent_id: str
+    timestamp: float
+    turn_index: int
+    token_count: int
+    context_window: tuple[dict[str, object], ...]
+    system_prompt_hash: str          # hash only — never plain text
+    taint_active: bool
+    external_read_count: int         # externally-sourced values registered this session
+    taint_canaries: tuple[str, ...] = field(default_factory=tuple)
+
+
+@runtime_checkable
+class ContextTap(Protocol):
+    """
+    Receives SessionContextView events from a GovernedSession.
+
+    axor-core defines this protocol; axor-probe implements it structurally
+    (CoreContextTap) without importing axor-core — dependency direction is
+    strictly one-way (P-34).
+
+    on_context_event MUST return promptly and must not block the governance
+    path: schedule any expensive work out-of-band (e.g. asyncio.create_task).
+    The session catches and logs tap exceptions — a failing observer never
+    disturbs execution — but it cannot defend against a tap that blocks.
+    """
+
+    async def on_context_event(self, view: SessionContextView) -> None:
+        """Called after each run() turn with the current context view."""
+        ...

--- a/axor_core/taint/engine.py
+++ b/axor_core/taint/engine.py
@@ -73,6 +73,10 @@ class TaintEngine:
         # against per-value tracking honestly.
         self._session_any_tainted = False
         self._session_any_sensitive = False
+        # Count of externally-sourced (tainted-root) value registrations this
+        # session. Observe-only telemetry, same spirit as the shadow flags —
+        # read by the SessionContextView observation seam, never by `allow`.
+        self._external_registrations = 0
         # Confidentiality floor (sound). An IDENTITY-BOUND registry of outstanding
         # sensitive reads: fingerprint(secret) -> count of un-released reads of THAT
         # exact secret. While non-empty the session is egress-restricted — soundly,
@@ -98,6 +102,7 @@ class TaintEngine:
         self._ledger.register(content, root)
         if root.is_tainted:
             self._session_any_tainted = True
+            self._external_registrations += 1
         if root.sensitive:
             self._session_any_sensitive = True
             # Arm the floor on the READ fact, keyed by the secret's fingerprint —
@@ -121,6 +126,14 @@ class TaintEngine:
         governance-released). An ENFORCEMENT input — unlike session_shadow. Once the
         outstanding map saturates it stays True (sticky) until governance clears."""
         return self._floor_saturated or bool(self._outstanding)
+
+    def external_read_count(self) -> int:
+        """Number of externally-sourced values registered this session.
+
+        Observe-only, like session_shadow — feeds the SessionContextView
+        observation seam, never an enforcement decision.
+        """
+        return self._external_registrations
 
     def session_shadow(self) -> tuple[bool, bool]:
         """(any_tainted, any_sensitive) for the session-wide shadow model.

--- a/axor_core/worker/session.py
+++ b/axor_core/worker/session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import time
@@ -15,6 +16,7 @@ from axor_core.contracts.session import SessionAuditRecord, ToolInvocationRecord
 from axor_core.contracts.context import RawExecutionState, LineageSummary
 from axor_core.contracts.extension import ExtensionLoader
 from axor_core.contracts.drift import BehavioralDriftObserver
+from axor_core.contracts.observation import ContextTap, SessionContextView
 from axor_core.contracts.invokable import Invokable
 from axor_core.contracts.mode import ExecutionMode
 from axor_core.contracts.policy import ExecutionPolicy, SignalClassifier
@@ -118,6 +120,7 @@ class GovernedSession:
         adjudicator=None,
         federation_gateway=None,
         session_sink: "SessionSink | None" = None,
+        context_taps: "list[ContextTap] | None" = None,
     ) -> None:
         # Wall-clock the session was constructed — handed to sentinel in the
         # closed-session record (slow-and-low staging compares session start times).
@@ -127,6 +130,9 @@ class GovernedSession:
         self._session_sink = session_sink
         self._tool_invocations: "list[ToolInvocationRecord]" = []
         self._record_emitted = False   # guard: aclose is idempotent, emit once
+        # Core → Probe observation seam: taps receive a SessionContextView after
+        # each run() turn. Observe-only — tap failures are logged, never raised.
+        self._context_taps: list[ContextTap] = list(context_taps or [])
 
         # Profile = a named bundle of existing knobs (no new mechanism); it
         # pre-fills mode / isolation / escalation / consequence-ceiling / watcher.
@@ -530,7 +536,72 @@ class GovernedSession:
             except Exception:
                 pass
 
+        # Core → Probe observation seam: push the post-turn context view to any
+        # attached ContextTaps. Observe-only, after all governance decisions.
+        await self._notify_context_taps()
+
         return result
+
+    # Fragment kind → provider message role for the observation seam. Kinds not
+    # listed (fact / memory / parent_export) read as user-supplied context.
+    _FRAGMENT_ROLES = {"skill": "system", "assistant_prose": "assistant",
+                       "tool_result": "tool"}
+
+    def _build_context_view(self) -> SessionContextView:
+        """Structural snapshot of the current session context for ContextTaps.
+
+        Built from shaped ContextFragments (never raw executor history) and the
+        taint engine's observe-only shadow counters.
+        """
+        fragments = self._context_manager.observable_fragments()
+        window = tuple(
+            {"role": self._FRAGMENT_ROLES.get(f.kind, "user"), "content": f.content}
+            for f in fragments
+        )
+        canaries = tuple(dict.fromkeys(
+            f.taint_mark for f in fragments if f.taint_mark
+        ))
+        personality = (
+            self._agent_def.personality
+            if self._agent_def is not None and self._agent_def.personality else ""
+        )
+        any_tainted, _ = self._taint_engine.session_shadow()
+        return SessionContextView(
+            session_id=self._session_id,
+            agent_id=self._agent_def.name if self._agent_def is not None else "",
+            timestamp=time.time(),
+            turn_index=self._context_manager.turn,
+            token_count=sum(f.token_estimate for f in fragments),
+            context_window=window,
+            system_prompt_hash=(
+                hashlib.sha256(personality.encode()).hexdigest() if personality else ""
+            ),
+            taint_active=bool(any_tainted),
+            external_read_count=self._taint_engine.external_read_count(),
+            taint_canaries=canaries,
+        )
+
+    async def _notify_context_taps(self) -> None:
+        """Push the current context view to attached taps. Must not raise — a
+        failing observer never disturbs the governance path."""
+        if not self._context_taps:
+            return
+        try:
+            view = self._build_context_view()
+        except Exception:
+            _log.warning(
+                "session: failed to build SessionContextView session=%s",
+                self._session_id, exc_info=True,
+            )
+            return
+        for tap in self._context_taps:
+            try:
+                await tap.on_context_event(view)
+            except Exception:
+                _log.warning(
+                    "session: context tap %r failed session=%s",
+                    type(tap).__name__, self._session_id, exc_info=True,
+                )
 
     async def notify_behavioral_drift(self, agent_id: str, action: str) -> None:
         """

--- a/tests/test_context_tap.py
+++ b/tests/test_context_tap.py
@@ -1,0 +1,101 @@
+"""Core → Probe observation seam: ContextTap / SessionContextView.
+
+The seam is observe-only: taps get a structural post-turn snapshot, tap
+failures never disturb the governance path, and the view is built from shaped
+ContextFragments — never raw executor history. axor-probe's CoreContextTap
+matches ContextTap structurally without importing axor-core (P-34), so the
+field set pinned here is the cross-repo contract.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from axor_core.capability.executor import CapabilityExecutor
+from axor_core.contracts.context import ContextFragment
+from axor_core.contracts.observation import ContextTap, SessionContextView
+from axor_core.contracts.taint import TaintSource
+from axor_core.taint.causal_root import CausalRoot
+from axor_core.worker.session import GovernedSession
+
+
+class _RecordingTap:
+    def __init__(self) -> None:
+        self.views: list[SessionContextView] = []
+
+    async def on_context_event(self, view: SessionContextView) -> None:
+        self.views.append(view)
+
+
+class _FailingTap:
+    async def on_context_event(self, view: SessionContextView) -> None:
+        raise RuntimeError("boom")
+
+
+def _session(*taps) -> GovernedSession:
+    cap = MagicMock(spec=CapabilityExecutor)
+    cap.register_post_callback = MagicMock()
+    return GovernedSession(
+        executor=MagicMock(),
+        capability_executor=cap,
+        context_taps=list(taps) or None,
+    )
+
+
+def test_recording_tap_satisfies_protocol():
+    assert isinstance(_RecordingTap(), ContextTap)
+
+
+async def test_tap_receives_structural_view():
+    tap = _RecordingTap()
+    session = _session(tap)
+    session._context_manager.pin_fragment(ContextFragment(
+        kind="skill", content="system rules", token_estimate=10,
+        source="agent:personality",
+    ))
+    session._context_manager.ingest_fragments([ContextFragment(
+        kind="fact", content="user fact", token_estimate=5, source="task",
+        taint_mark="AXOR_CANARY_deadbeef",
+    )])
+    session._taint_engine.register_value(
+        "external payload", CausalRoot.external_read(TaintSource.WEB)
+    )
+
+    await session._notify_context_taps()
+
+    assert len(tap.views) == 1
+    view = tap.views[0]
+    assert view.session_id == session.session_id()
+    assert view.taint_active is True
+    assert view.external_read_count == 1
+    assert view.taint_canaries == ("AXOR_CANARY_deadbeef",)
+    assert view.token_count == 15
+    # Fragment kinds map onto provider message roles; content is the shaped
+    # fragment content, never raw history.
+    assert {"role": "system", "content": "system rules"} in view.context_window
+    assert {"role": "user", "content": "user fact"} in view.context_window
+
+
+async def test_view_carries_probe_expected_fields():
+    # The exact attribute set axor-probe's _SessionContextViewLike declares.
+    tap = _RecordingTap()
+    session = _session(tap)
+    await session._notify_context_taps()
+    view = tap.views[0]
+    for attr in (
+        "session_id", "agent_id", "timestamp", "turn_index", "token_count",
+        "context_window", "system_prompt_hash", "taint_active",
+        "external_read_count", "taint_canaries",
+    ):
+        assert hasattr(view, attr), attr
+
+
+async def test_failing_tap_is_swallowed_and_others_still_fire():
+    recorder = _RecordingTap()
+    session = _session(_FailingTap(), recorder)
+    await session._notify_context_taps()  # no raise
+    assert len(recorder.views) == 1
+
+
+async def test_no_taps_is_noop():
+    session = _session()
+    await session._notify_context_taps()  # no raise, no work


### PR DESCRIPTION
## Summary

axor-probe's `CoreContextTap` was written against a `ContextTap` protocol in `axor_core/contracts/observation.py` that never existed in core (confirmed against full git history) — the probe had no seam to attach to, so it could not be triggered from a live session, and its new canary health-check channel (`taint_canaries`) hung in the air. This PR adds the seam, closing finding #2 of the cross-repo contracts review.

## Changes

- **`contracts/observation.py`** (new): `SessionContextView` — a frozen structural post-turn context snapshot (`session_id`, `agent_id`, `timestamp`, `turn_index`, `token_count`, `context_window`, `system_prompt_hash`, `taint_active`, `external_read_count`, `taint_canaries`) — and the `ContextTap` protocol. Field set matches probe's `_SessionContextViewLike` mirror exactly; probe implements it structurally without importing core (P-34). Exported from `contracts/__init__.py`.
- **`GovernedSession(context_taps=[...])`**: pushes a view to each tap after every `run()` turn. Observe-only — built from shaped `ContextFragment`s (never raw executor history), tap exceptions are logged and swallowed, nothing a tap does can reach the allow/deny path.
- **`ContextManager.turn` / `observable_fragments()`**: read-only accessors feeding the view builder.
- **`TaintEngine.external_read_count()`**: counts tainted-root value registrations — observe-only telemetry in the same spirit as the session shadow, never an enforcement input.
- `taint_canaries` is drawn from the distinct `ContextFragment.taint_mark` tokens live in context, so a probe can check whether the agent leaks one into its output (the clean shadow never holds them).
- CHANGELOG entry under Unreleased.

## Testing

- New `tests/test_context_tap.py`: view structure (incl. canaries, external-read count, role mapping), probe-expected field set, failing-tap isolation, no-tap noop, protocol `isinstance` check.
- Full suite: **874 passed, 2 skipped, 8 xfailed**.
- Cross-repo, against the real axor-probe checkout: `CoreContextTap` satisfies `ContextTap`, and `ViewSnapshotFactory` maps a real `SessionContextView` (canaries included). The probe side pins this permanently in its own suite (see companion probe PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XuxrXmun9idG57E2erSPYt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuxrXmun9idG57E2erSPYt)_