### PR TITLE
Multi-agent runtime layer (spec v2): envelopes, boundary gates, trust ladder, causal subgraph — 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@
 
 (nothing yet)
 
+## 0.9.2 — 2026-07-13
+
+The multi-agent runtime layer (spec v2): labels ride in message envelopes,
+boundary gates run locally on both edge ends, and inter-federation trust is a
+ladder — discount, never label authority.
+
+### Added
+
+- **Kernel messaging (`kernel/messaging.py`, Ch.4).** New event kinds
+  `NODE_SPAWNED` / `MESSAGE_SENT` / `MESSAGE_RECEIVED`; the pure sender-side
+  gate `evaluate_message_send` (LOCKED admits no sends; undeclared peer edges
+  fail closed) and `fold_carried_root` (a message that lost its labels re-mints
+  untrusted). `replay()` folds `MESSAGE_RECEIVED` with carried labels intact and
+  monotonically on cycles (A→B→A cannot launder); `replay_tree()` folds a
+  multi-node trace per node — no shared governance state; size-1 degenerates to
+  exactly `replay()`.
+- **Runtime messaging (`node/messaging.py`).** `MessageEnvelope` (labels travel
+  with the value; federation-key signable, tamper → rejected) and
+  `InMemoryMessageBus` emitting kernel events on both edge ends. Peer-edge
+  delivery re-derives through the trust ladder; the foreign root is kept as an
+  opaque forensic ref beside the minted local root.
+- **Inter-federation trust ladder (`federation/ladder.py`, Ch.1).**
+  `PeerDeclaration` (undeclared = L0), `receive_foreign` (L0 full taint / L1
+  attribution-only / L2 bounded discount never-to-clean, floor never
+  peer-negotiable; forged assertion falls to L0 evidenced),
+  `effective_root_for_sink` (critical sinks ignore discounts entirely),
+  `establish_channel` (MCP-as-A2A pinned L0/L1; governance attestation —
+  signed kernel+config-hash — verified at establishment, failures evidenced).
+  The gateway restore path is documented as intra-keyset-only.
+- **Causal subgraph (`kernel/subgraph.py`, Ch.3).** Backward provenance walk
+  from an anchored claim/denial: minimal causes, roles
+  (origin/conduit/container/anchor), `fault_origin`, `contained_at`,
+  `federation_scope`; message hops become subgraph edges with carried labels.
+- **Spawn & death (Ch.4).** `node/spawn.inherit_degradation` — opt-in per-node
+  degradation (`per_node_degradation` on `GovernedSession`/`GovernedNode`):
+  a child starts at max(parent level, NORMAL), narrow-or-preserve. A crashed
+  child leaves a `CHILD_STALE` trace event and tightens the parent to CAUTIOUS
+  (bridged to a kernel `node_stale` FACT) — absence is a fact, never a clean
+  return.
+- **Bridge.** `CHILD_SPAWNED` → `NODE_SPAWNED`, `CHILD_COMPLETED` →
+  `MESSAGE_RECEIVED` (delegation), `CHILD_STALE` → FACT `node_stale`.
+
+### Compatibility
+
+- Additive only: a single node is a tree with no edges — the v0.13 single-agent
+  paths are unchanged and the 0.9.1 suite passes unmodified (the platform's
+  size-1 golden gate pins byte-identical behavior end-to-end).
+
 ## 0.9.1 — 2026-07-10
 
 The kernel/platform split and one-implementation gate engine.

--- a/axor_core/contracts/trace.py
+++ b/axor_core/contracts/trace.py
@@ -28,6 +28,9 @@ class TraceEventKind(str, Enum):
     # federation
     CHILD_SPAWNED = "child_spawned"
     CHILD_COMPLETED = "child_completed"
+    # Crash/disappearance: the child never returned; absence is a fact at the
+    # parent (spec v2 Ch.4 section 4), never a clean return.
+    CHILD_STALE = "child_stale"
 
     # context
     CONTEXT_COMPRESSED = "context_compressed"
@@ -126,6 +129,15 @@ class ChildSpawnedEvent(TraceEvent):
     child_node_id: str = ""
     child_depth: int = 0
     context_fraction: float = 0.0
+
+
+@dataclass(frozen=True)
+class ChildStaleEvent(TraceEvent):
+    """The parent's pending receive on a spawn edge ended without a result
+    (crash, disappearance). Bridged to a kernel FACT ``node_stale`` — a
+    crashed child cannot silently be treated as having returned clean."""
+
+    child_node_id: str = ""
 
 
 @dataclass(frozen=True)

--- a/axor_core/federation/__init__.py
+++ b/axor_core/federation/__init__.py
@@ -8,6 +8,13 @@ L2 — a value from an authenticated peer in a federated domain running a compat
      kernel, carrying a valid provenance receipt, has its provenance restored (we
      trust the peer's labels instead of re-minting). A forged or tampered receipt is
      denied; an incompatible kernel or non-federated domain degrades to L1.
+
+SCOPE (spec v2 Ch.1, decision v2-1/v2-2): the RESTORE path above is legitimate
+only where the peer is governed under OUR operator keyset — `federated_domains`
+means our own domains (intra-federation, where labels are data). For a peer
+under a DIFFERENT keyset, labels are claims: use
+:mod:`axor_core.federation.ladder` (L0/L1/L2 + governance_attested — bounded
+discount, never label authority, forgery falls to L0 evidenced).
 """
 
 from axor_core.federation.signing import (

--- a/axor_core/federation/ladder.py
+++ b/axor_core/federation/ladder.py
@@ -1,0 +1,161 @@
+"""Inter-federation trust ladder (spec v2 Ch.1 §2) — foreign labels are CLAIMS.
+
+This module is the spec-v2 alignment of federation semantics for peers under a
+DIFFERENT operator keyset. The existing :mod:`axor_core.federation.gateway`
+restore path ("trust the peer's labels") is only legitimate where the keyset is
+ours — intra-federation, where labels are data. Across keysets, declaration
+buys DISCOUNT, never label authority (decision v2-2):
+
+  L0 (default, undeclared)  full taint on everything inbound; the peer is an
+                            untrusted export destination outbound.
+  L1 (authenticated)        identity verified — reputation can accrue to a
+                            stable peer. Inbound taint UNCHANGED: L1 buys
+                            attribution, not trust.
+  L2 (federated agreement)  the peer's signed label assertions are accepted as
+                            EVIDENCE with a policy-declared discount — bounded
+                            steps per (peer, message class), never to clean,
+                            never affecting the confidentiality floor.
+  + governance_attested     the peer proves it runs under axor-core (signed
+                            kernel version + config hash): trust in MECHANISM,
+                            higher declared discounts — still not authority.
+
+Critical sinks ignore discounts entirely (decision v2-3):
+:func:`effective_root_for_sink` returns the undiscounted root for a critical
+sink, making criticality non-negotiable by the peer.
+
+A forged assertion falls to L0 handling and the fall is EVIDENCED (an event,
+not a silent downgrade) — spec v2 Ch.1 eval scenarios.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from axor_core.contracts.taint import TaintSource
+from axor_core.federation.signing import Verifier
+from axor_core.taint.causal_root import CausalRoot
+
+L0 = "l0"
+L1 = "l1"
+L2 = "l2"
+_LEVELS = (L0, L1, L2)
+
+
+@dataclass(frozen=True)
+class PeerDeclaration:
+    """Operator-declared foreign peer (config-resident, like a sink).
+
+    Undeclared peers do not get a declaration object at all — they ARE L0.
+    ``discount_classes`` lists the message classes the L2 discount applies to;
+    ``governance_attested`` marks a verified kernel+config-hash attestation
+    (fact of governance only, decision v2-6).
+    """
+
+    peer_id: str
+    level: str = L0
+    verifier: Verifier | None = None
+    discount_classes: frozenset[str] = frozenset()
+    governance_attested: bool = False
+
+    def __post_init__(self) -> None:
+        if self.level not in _LEVELS:
+            raise ValueError(f"unknown trust level {self.level!r}")
+        if self.level in (L1, L2) and self.verifier is None:
+            raise ValueError(f"{self.level} requires a verifier (authenticated identity)")
+
+
+@dataclass(frozen=True)
+class LabelAssertion:
+    """A peer's signed claim about a value's labels (L2 evidence envelope).
+    Native-protocol-only (decision v2-4); MCP-as-A2A channels never carry one."""
+
+    peer_id: str
+    message_class: str
+    sources: tuple[str, ...]
+    sensitive: bool
+    payload: bytes  # canonical bytes the signature covers
+    signature: bytes
+
+
+@dataclass(frozen=True)
+class InboundVerdict:
+    """The result of receiving a foreign value: the local root to register,
+    the undiscounted root (critical sinks use this), and the evidence trail."""
+
+    root: CausalRoot
+    full_root: CausalRoot
+    level: str
+    discounted: bool
+    evidence: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _full_taint(sensitive: bool) -> CausalRoot:
+    base = CausalRoot.cross_process_in()
+    if sensitive:
+        return CausalRoot(sources=base.sources, sensitive=True)
+    return base
+
+
+def receive_foreign(
+    value_sensitive_hint: bool,
+    declaration: PeerDeclaration | None,
+    assertion: LabelAssertion | None = None,
+) -> InboundVerdict:
+    """Derive the local root for a value arriving from a FOREIGN keyset.
+
+    The foreign causal_root is never grafted onto ours — a local root is
+    minted; whatever the peer asserted rides along only as bounded discount
+    evidence. ``value_sensitive_hint`` is OUR channel-level knowledge (e.g.
+    the channel is declared secret-bearing); a peer's "not sensitive" claim
+    can never clear it (the floor is not negotiable by the peer).
+    """
+    full = _full_taint(value_sensitive_hint)
+    if declaration is None:
+        return InboundVerdict(full, full, L0, False, ("undeclared_peer_l0",))
+    if declaration.level == L0 or assertion is None:
+        return InboundVerdict(full, full, declaration.level, False)
+
+    # L1/L2: the assertion must verify against the declared identity. A forged
+    # assertion FALLS to L0 handling, evidenced — never silently accepted,
+    # never a hard crash that loses the value's audit trail.
+    if declaration.verifier is None or not declaration.verifier.verify(
+        assertion.payload, assertion.signature
+    ):
+        return InboundVerdict(
+            full, full, L0, False,
+            (f"assertion_forged_fell_to_l0:{declaration.peer_id}",),
+        )
+
+    if declaration.level == L1:
+        # Attribution, not trust: identity verified, taint unchanged.
+        return InboundVerdict(full, full, L1, False, ("l1_attribution_only",))
+
+    # L2: bounded discount for declared message classes only.
+    if assertion.message_class not in declaration.discount_classes:
+        return InboundVerdict(
+            full, full, L2, False,
+            (f"class_not_discounted:{assertion.message_class}",),
+        )
+    asserted = frozenset(
+        TaintSource(s) for s in assertion.sources
+        if s in TaintSource._value2member_map_
+    )
+    # Never to clean: an empty asserted source set keeps the untrusted re-mint
+    # source. Never affecting the confidentiality floor: our sensitivity hint
+    # (and the peer's own sensitive=True) survive; sensitive=False from the
+    # peer cannot clear our hint.
+    sources = asserted if asserted else frozenset({TaintSource.UNKNOWN_EXTERNAL})
+    sensitive = value_sensitive_hint or assertion.sensitive
+    discounted = CausalRoot(sources=sources, sensitive=sensitive)
+    evidence = ("l2_discount_applied",) + (
+        ("governance_attested",) if declaration.governance_attested else ()
+    )
+    return InboundVerdict(discounted, full, L2, True, evidence)
+
+
+def effective_root_for_sink(
+    verdict: InboundVerdict, sink_is_critical: bool
+) -> CausalRoot:
+    """Critical sinks ignore L2 discounts entirely (decision v2-3): a discount
+    that could reach a critical sink would make criticality negotiable by the
+    peer. Pure predicate — shared by runtime and replay (Rule 0)."""
+    return verdict.full_root if sink_is_critical else verdict.root

--- a/axor_core/federation/ladder.py
+++ b/axor_core/federation/ladder.py
@@ -152,6 +152,81 @@ def receive_foreign(
     return InboundVerdict(discounted, full, L2, True, evidence)
 
 
+@dataclass(frozen=True)
+class GovernanceAttestation:
+    """A peer's signed proof it runs under axor-core: kernel version + config
+    hash (fact of governance only, decision v2-6 — the hash pins
+    accountability, never semantics; foreign configs are not parsed)."""
+
+    peer_id: str
+    kernel_version: str
+    config_hash: str
+    signature: bytes
+
+    def payload(self) -> bytes:
+        return (
+            f"governance{self.peer_id}{self.kernel_version}"
+            f"{self.config_hash}"
+        ).encode()
+
+
+@dataclass(frozen=True)
+class ChannelGrant:
+    """The result of establishing a peer channel (protocol v0.2 §6a):
+    the EFFECTIVE level the channel is pinned at, and why."""
+
+    peer_id: str
+    level: str
+    governance_attested: bool
+    config_hash: str | None
+    evidence: tuple[str, ...] = field(default_factory=tuple)
+
+
+def establish_channel(
+    declaration: PeerDeclaration | None,
+    *,
+    transport: str = "native",
+    attestation: GovernanceAttestation | None = None,
+) -> ChannelGrant:
+    """Channel establishment verifies the peer declaration from local config
+    (protocol v0.2 §6a). Undeclared = L0. MCP-as-A2A is pinned L0/L1 at
+    establishment (decision v2-4) — the L2 assertion envelope arrives with the
+    native protocol only. ``governance_attested`` requires a VALID signed
+    kernel+config-hash attestation; verification is repeated on config-hash
+    change by re-establishing (the grant records the hash it verified)."""
+    if declaration is None:
+        return ChannelGrant("", L0, False, None, ("undeclared_peer_l0",))
+
+    level = declaration.level
+    evidence: list[str] = []
+    if transport == "mcp" and level == L2:
+        level = L1
+        evidence.append("mcp_transport_pinned_l1")
+
+    attested = False
+    config_hash: str | None = None
+    if declaration.governance_attested:
+        if (
+            attestation is not None
+            and declaration.verifier is not None
+            and attestation.peer_id == declaration.peer_id
+            and declaration.verifier.verify(
+                attestation.payload(), attestation.signature
+            )
+        ):
+            attested = True
+            config_hash = attestation.config_hash
+            evidence.append("governance_attestation_verified")
+        else:
+            # A declared-attested peer that cannot prove it: the channel still
+            # establishes at the declared level, but WITHOUT the attested
+            # standing (lower discounts apply) — and the failure is evidenced.
+            evidence.append("governance_attestation_failed")
+    return ChannelGrant(
+        declaration.peer_id, level, attested, config_hash, tuple(evidence)
+    )
+
+
 def effective_root_for_sink(
     verdict: InboundVerdict, sink_is_critical: bool
 ) -> CausalRoot:

--- a/axor_core/kernel/events.py
+++ b/axor_core/kernel/events.py
@@ -28,6 +28,23 @@ replay agree on these keys):
   derivations; already-derived values keep their taint (spec 8.2.1)
 - OPERATOR_INTERVENTION / INJECTION_CONSUMED / STATE_APPLIED / HEARTBEAT:
   control-plane bookkeeping (protocol note sections 4-5)
+
+Multi-agent kinds (spec v2 Ch.4 — labels ride in message envelopes; structure
+derives from traced spawn events, never from self-report):
+
+- NODE_SPAWNED: ``{"child_id", "parent_id", "depth", "edge_kind":
+  "delegation"}`` — emitted at the PARENT; replay reconstructs the tree shape
+  from these, the platform derives topology from the same events.
+- MESSAGE_SENT: ``{"to", "edge_kind": "delegation"|"lateral"|"peer",
+  "msg_id", "value_ref", "carried": {"root": {"sources": [...],
+  "sensitive"}}}`` — the message is a sink at the sender; ``verdict`` is the
+  sender-side gate verdict, ``gate`` the denying category. A DENY here is
+  containment at the source (spec v2 Ch.2).
+- MESSAGE_RECEIVED: ``{"from", "edge_kind", "msg_id", "value_ref",
+  "carried": {"root": ...}}`` — the message is a source at the receiver; the
+  fold registers ``value_ref`` under the CARRIED root (labels travel with
+  values, spec v2 Ch.1 §1 — intra-federation labels are data, not claims).
+  ``msg_id`` stitches cross-node causality (no global clock, Ch.4 §5).
 """
 from __future__ import annotations
 
@@ -56,6 +73,10 @@ class EventKind(str, Enum):
     INJECTION_REFUSED = "injection_refused"
     EXCISION_REFUSED = "excision_refused"
     HEARTBEAT = "heartbeat"
+    # Multi-agent (spec v2 Ch.4). Additive; absent from any size-1 trace.
+    NODE_SPAWNED = "node_spawned"
+    MESSAGE_SENT = "message_sent"
+    MESSAGE_RECEIVED = "message_received"
 
 
 class Verdict(str, Enum):

--- a/axor_core/kernel/messaging.py
+++ b/axor_core/kernel/messaging.py
@@ -1,0 +1,74 @@
+"""Pure boundary-gate predicates for inter-node messages (spec v2 Ch.4 §2).
+
+A boundary is an edge between two nodes; the gate runs at the SENDER on the
+send (message-as-sink) and at the RECEIVER on the receipt (message-as-source).
+Two independent local evaluations — no distributed transaction, no shared
+state. The verdict-deciding code lives here, in the pure kernel, shared by the
+runtime (axor_core.node.messaging) and replay (Rule 0).
+
+Intra-federation semantics (spec v2 Ch.1 §1): labels are DATA — they travel
+with values and are folded intact at the receiver. Being internal grants no
+permissions; it only preserves label fidelity. Hop count cleans nothing.
+"""
+from __future__ import annotations
+
+from axor_core.contracts.degradation import DegradationLevel
+from axor_core.policy.gates import GateDecision
+from axor_core.taint.causal_root import CausalRoot
+
+EDGE_DELEGATION = "delegation"
+EDGE_LATERAL = "lateral"
+EDGE_PEER = "peer"
+EDGE_KINDS = frozenset({EDGE_DELEGATION, EDGE_LATERAL, EDGE_PEER})
+
+
+def evaluate_message_send(
+    sender_level: DegradationLevel,
+    root: CausalRoot,
+    edge_kind: str,
+    *,
+    peer_declared: bool = False,
+) -> GateDecision | None:
+    """Sender-side gate: the message is a sink. None = pass.
+
+    - Unknown edge kind: deny (fail closed, same posture as an unclassified
+      sink).
+    - LOCKED/TERMINAL sender: deny — a locked node admits only read/escalate;
+      sending a value laterally would be an effect.
+    - PEER edge to an undeclared peer: deny (spec v2 Ch.1 §2 — undeclared =
+      L0 = untrusted export destination; establishing the channel at all
+      requires a declaration). Declared-peer gating (levels, discounts) is the
+      inter-federation ladder — layered on top of this predicate, never
+      replacing it.
+    - Intra edges (delegation/lateral) carry labels intact; taint does NOT
+      deny the send — it rides with the value and denies at the next sink
+      that matters. That is carried-taint containment, not laundering.
+    """
+    if edge_kind not in EDGE_KINDS:
+        return GateDecision(
+            reason=f"message: unknown edge kind '{edge_kind}' (undeclared = denied)",
+            category="message_gate",
+        )
+    if sender_level >= DegradationLevel.LOCKED:
+        return GateDecision(
+            reason=(
+                f"degradation: level {sender_level.name} admits no message sends"
+            ),
+            category="degradation",
+        )
+    if edge_kind == EDGE_PEER and not peer_declared:
+        return GateDecision(
+            reason="message: peer edge to an undeclared peer (undeclared = L0, denied)",
+            category="message_gate",
+        )
+    return None
+
+
+def fold_carried_root(root: CausalRoot | None) -> CausalRoot:
+    """Receiver-side fold of a carried root, intra-federation: labels are data
+    and arrive intact — the carried root IS the local root. A missing root
+    fails closed to an untrusted cross-process re-mint (a message that lost
+    its labels must not arrive clean)."""
+    if root is None:
+        return CausalRoot.cross_process_in()
+    return root

--- a/axor_core/kernel/replay.py
+++ b/axor_core/kernel/replay.py
@@ -48,6 +48,7 @@ from axor_core.kernel.events import (
     fact_from_payload,
 )
 from axor_core.kernel.errors import SchemaVersionError
+from axor_core.kernel.messaging import fold_carried_root
 from axor_core.kernel.state import GovernanceState
 from axor_core.policy.gates import (
     GateDecision,
@@ -326,6 +327,25 @@ def replay(
                     state.tainted_refs[str(ref)] = root
                 if root.sensitive:
                     state.floor_active = True
+        elif event.kind is EventKind.MESSAGE_RECEIVED:
+            # The message is a source (spec v2 Ch.4 §2): the carried root is
+            # folded INTACT into local state — labels travel with values
+            # (Ch.1 §1). A message that lost its labels re-mints untrusted
+            # (fold_carried_root fails closed); cycles re-fold monotonically —
+            # a value returning to its origin cannot arrive cleaner.
+            ref = event.payload.get("value_ref") or event.causal_root
+            if ref:
+                carried = (event.payload.get("carried") or {}).get("root")
+                root = fold_carried_root(
+                    root_from_payload(carried) if carried is not None else None
+                )
+                prior = state.tainted_refs.get(str(ref))
+                if prior is not None:
+                    root = CausalRoot.mint(prior, root)
+                if root.is_tainted or root.sensitive:
+                    state.tainted_refs[str(ref)] = root
+                if root.sensitive:
+                    state.floor_active = True
         elif event.kind is EventKind.FACT:
             fact = fact_from_payload(event.payload)
             state.facts[fact.fact_id] = fact
@@ -353,3 +373,27 @@ def replay(
         )
 
     return ReplayResult(steps=tuple(steps), first_divergence=first_divergence)
+
+
+def replay_tree(
+    events: Sequence[Event], config: KernelConfig | None = None
+) -> dict[str, ReplayResult]:
+    """Fold a multi-node trace: each node's local sequence independently.
+
+    There is no shared governance state (spec v2 Ch.4 §1 / decision v2-13):
+    a node's gates see only its local state plus the labels carried in on its
+    own MESSAGE_RECEIVED events. Cross-node order is established only by
+    message causality (msg_id send→receive), which each node's local fold
+    already respects — independent events are genuinely unordered and their
+    interleaving cannot affect any verdict.
+
+    A single-node trace degenerates to exactly one replay() result — the
+    size-1 path is byte-identical to the v0.13 fold.
+    """
+    by_node: dict[str, list[Event]] = {}
+    for e in events:
+        by_node.setdefault(e.node_id, []).append(e)
+    return {
+        node_id: replay(sorted(node_events, key=lambda e: e.seq), config)
+        for node_id, node_events in by_node.items()
+    }

--- a/axor_core/kernel/subgraph.py
+++ b/axor_core/kernel/subgraph.py
@@ -1,0 +1,188 @@
+"""The causal subgraph — the multi-agent EvidenceCase core (spec v2 Ch.3).
+
+``causal_subgraph`` walks causal-root provenance BACKWARD from an anchored
+claim/denial and returns the minimal subgraph whose events causally contribute
+to the discrepancy — the causes, not the org chart. A 40-node tree with a
+3-node causal chain yields a 3-node case.
+
+Pure kernel (Rule 0): derived from the trace deterministically, computed on
+case open, never stored (decision v2-12). A size-1 result — the anchor as the
+only node, no edges — IS the v0.13 case; renderers branch on subgraph size.
+
+Roles per node (one node can hold several):
+  origin     — a fault landed here
+  conduit    — propagated through (taint carried, not laundered)
+  container  — denied propagation here
+  anchor     — the claim reached a consequence here
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from axor_core.kernel.events import Event, EventKind, Verdict
+
+ROLE_ORIGIN = "origin"
+ROLE_CONDUIT = "conduit"
+ROLE_CONTAINER = "container"
+ROLE_ANCHOR = "anchor"
+
+
+def causal_subgraph(
+    events: Sequence[Event], anchor_node: str, anchor_seq: int
+) -> dict:
+    """Backward provenance walk from the anchor event.
+
+    The anchor is where the discrepancy surfaced — an export attempt, a claim,
+    a returned answer (one case per consequence, decision v2-10). Returns a
+    JSON-able dict; raises ValueError when the anchor event does not exist.
+    """
+    by_node: dict[str, list[Event]] = {}
+    for e in events:
+        by_node.setdefault(e.node_id, []).append(e)
+    for seq_events in by_node.values():
+        seq_events.sort(key=lambda e: e.seq)
+
+    anchor_ev = next(
+        (e for e in by_node.get(anchor_node, ())
+         if e.seq == anchor_seq), None,
+    )
+    if anchor_ev is None:
+        raise ValueError(f"no event seq={anchor_seq} at node {anchor_node!r}")
+
+    # msg_id -> (sent event, received event): the cross-node stitch (Ch.4 §5).
+    sends: dict[str, Event] = {}
+    receives: dict[str, Event] = {}
+    for e in events:
+        mid = e.payload.get("msg_id")
+        if not mid:
+            continue
+        if e.kind is EventKind.MESSAGE_SENT:
+            sends[str(mid)] = e
+        elif e.kind is EventKind.MESSAGE_RECEIVED:
+            receives[str(mid)] = e
+
+    roles: dict[str, set[str]] = {anchor_node: {ROLE_ANCHOR}}
+    edges: list[dict] = []
+    contained_at: list[dict] = []
+    fault_origin: dict | None = None
+    case_seqs: dict[str, set[int]] = {anchor_node: {anchor_seq}}
+
+    # Containment at the anchor itself: a denied consequence is the positive-
+    # space case (verdict CONTAINED, decision v2-11).
+    if anchor_ev.verdict is Verdict.DENY:
+        roles[anchor_node].add(ROLE_CONTAINER)
+        contained_at.append({
+            "from": anchor_node,
+            "to": str(anchor_ev.payload.get("tool")
+                      or anchor_ev.payload.get("to") or "export"),
+            "kind": "export" if anchor_ev.kind is EventKind.TOOL_CALL else "message",
+            "gate": anchor_ev.gate,
+            "seq": anchor_ev.seq,
+        })
+
+    def driving_refs(e: Event) -> list[str]:
+        arg_refs = e.payload.get("arg_refs") or {}
+        if arg_refs:
+            return [str(r) for r in arg_refs.values()]
+        ref = e.payload.get("value_ref") or e.causal_root
+        return [str(ref)] if ref else []
+
+    # Frontier of (node, ref) pairs still to be explained.
+    frontier: list[tuple[str, str]] = [
+        (anchor_node, r) for r in driving_refs(anchor_ev)
+    ]
+    # For a claim/denial with no refs, fall back to the node's last received
+    # or derived value — the claim was assembled from what arrived.
+    if not frontier:
+        for e in reversed(by_node[anchor_node]):
+            if e.seq >= anchor_seq:
+                continue
+            if e.kind in (EventKind.MESSAGE_RECEIVED, EventKind.TOOL_RESULT):
+                ref = e.payload.get("value_ref") or e.causal_root
+                if ref:
+                    frontier.append((anchor_node, str(ref)))
+                    break
+
+    seen: set[tuple[str, str]] = set()
+    while frontier:
+        node, ref = frontier.pop()
+        if (node, ref) in seen:
+            continue
+        seen.add((node, ref))
+        node_events = by_node.get(node, [])
+
+        # Producer of `ref` at `node`: latest registration before it was used.
+        producer: Event | None = None
+        for e in reversed(node_events):
+            if e.kind in (EventKind.MESSAGE_RECEIVED, EventKind.TOOL_RESULT) and (
+                str(e.payload.get("value_ref") or e.causal_root or "") == ref
+            ):
+                producer = e
+                break
+        if producer is None:
+            continue
+        case_seqs.setdefault(node, set()).add(producer.seq)
+
+        if producer.kind is EventKind.MESSAGE_RECEIVED:
+            mid = str(producer.payload.get("msg_id") or "")
+            sent = sends.get(mid)
+            sender = str(producer.payload.get("from") or
+                         (sent.node_id if sent else ""))
+            if sender:
+                roles.setdefault(sender, set()).add(ROLE_CONDUIT)
+                edge = {
+                    "from": sender,
+                    "to": node,
+                    "kind": str(producer.payload.get("edge_kind", "lateral")),
+                    "carried": producer.payload.get("carried") or {},
+                    "gate_verdict": (sent.verdict.value
+                                     if sent and sent.verdict else None),
+                    "msg_id": mid or None,
+                }
+                if edge not in edges:
+                    edges.append(edge)
+                # Continue the walk at the sender.
+                frontier.append((sender, ref))
+                if sent is not None:
+                    case_seqs.setdefault(sender, set()).add(sent.seq)
+        elif producer.kind is EventKind.TOOL_RESULT:
+            tool = producer.payload.get("tool")
+            # A fault injected into this tool at this node = the origin.
+            for e in node_events:
+                if (e.kind is EventKind.FAULT_INJECTED
+                        and e.payload.get("tool") == tool
+                        and e.seq <= producer.seq):
+                    roles.setdefault(node, set()).add(ROLE_ORIGIN)
+                    if fault_origin is None:
+                        fault_origin = {"node_id": node, "seq": e.seq}
+                    case_seqs.setdefault(node, set()).add(e.seq)
+            # The producing call's own inputs continue the chain (derivation
+            # stays intra-node; only message hops become subgraph edges).
+            for e in reversed(node_events):
+                if (e.kind is EventKind.TOOL_CALL
+                        and e.seq < producer.seq
+                        and e.payload.get("tool") == tool):
+                    for up_ref in (e.payload.get("arg_refs") or {}).values():
+                        frontier.append((node, str(up_ref)))
+                    case_seqs.setdefault(node, set()).add(e.seq)
+                    break
+
+    # A node that only relayed (roles == {conduit}) stays conduit; the anchor
+    # never doubles as conduit of its own claim.
+    roles.get(anchor_node, set()).discard(ROLE_CONDUIT)
+
+    nodes = [
+        {"node_id": nid, "roles": sorted(rs),
+         "seqs": sorted(case_seqs.get(nid, ()))}
+        for nid, rs in sorted(roles.items())
+    ]
+    return {
+        "anchor": {"node_id": anchor_node, "seq": anchor_seq},
+        "nodes": nodes,
+        "edges": edges,
+        "fault_origin": fault_origin,
+        "contained_at": contained_at or None,
+        "federation_scope": (
+            "inter" if any(e["kind"] == "peer" for e in edges) else "intra"
+        ),
+    }

--- a/axor_core/node/messaging.py
+++ b/axor_core/node/messaging.py
@@ -1,0 +1,241 @@
+"""Lateral / delegation message transport with labels in the envelope.
+
+Runtime orchestration around the pure kernel predicates (spec v2 Ch.4):
+labels ride in the message envelope; the gate runs at the sender on the send
+and at the receiver on the receipt — two local evaluations, never a joint
+computation. Networked intra edges are signed with federation keys —
+signature proves integrity and origin, it does NOT trigger re-derivation
+(same authority on both ends, spec v2 Ch.1 §1). Intra lateral edges go
+direct, never through the plane (decision v2-5).
+
+Nothing in this module decides a verdict: that is
+:func:`axor_core.kernel.messaging.evaluate_message_send` and
+:func:`axor_core.kernel.messaging.fold_carried_root` (Rule 0).
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+
+from axor_core.contracts.degradation import DegradationLevel
+from axor_core.federation.signing import Signer, Verifier
+from axor_core.kernel.events import Event, EventKind, Verdict
+from axor_core.kernel.messaging import (
+    EDGE_KINDS,
+    evaluate_message_send,
+    fold_carried_root,
+)
+from axor_core.policy.gates import GateDecision
+from axor_core.taint.causal_root import CausalRoot
+from axor_core.taint.engine import TaintEngine
+from axor_core.taint.fingerprint import content_fingerprint
+
+
+class MessageDenied(Exception):
+    """Sender-side gate denied the send; the message was never delivered."""
+
+    def __init__(self, decision: GateDecision) -> None:
+        super().__init__(decision.reason)
+        self.decision = decision
+
+
+class MessageRejected(Exception):
+    """Receiver-side rejection: a signed envelope failed verification. A forged
+    or tampered envelope is an attack, not a downgrade — never folded."""
+
+
+@dataclass(frozen=True)
+class MessageEnvelope:
+    """A value in transit between two nodes, labels riding with it.
+
+    ``root`` is the value's causal root AT THE SENDER — carried intact across
+    intra edges (labels are data inside one federation). ``value_ref`` is the
+    stable ref both trace events use, so replay and the causal-subgraph walk
+    stitch send→receive without content access.
+    """
+
+    msg_id: str
+    from_node: str
+    to_node: str
+    edge_kind: str
+    value: object
+    root: CausalRoot
+    value_ref: str = ""
+    signature: bytes = b""
+    algorithm: str = ""
+
+    def signed_payload(self) -> bytes:
+        """Canonical byte string the federation signature covers. Binds
+        identity, edge, value hash and labels — an envelope cannot be detached
+        from its value or have its labels stripped without breaking the sig."""
+        src = ",".join(sorted(s.value for s in self.root.sources))
+        vh = content_fingerprint(self.value)
+        return (
+            f"{self.msg_id}\x1f{self.from_node}\x1f{self.to_node}"
+            f"\x1f{self.edge_kind}\x1f{vh}\x1f{src}\x1f{int(self.root.sensitive)}"
+        ).encode()
+
+
+def make_envelope(
+    sender: TaintEngine,
+    from_node: str,
+    to_node: str,
+    edge_kind: str,
+    value: object,
+    *,
+    value_ref: str | None = None,
+    signer: Signer | None = None,
+) -> MessageEnvelope:
+    """Build an envelope for ``value``, deriving its labels from the sender's
+    own per-value ledger (the value's ACTUAL provenance — clean stays clean,
+    tainted stays tainted; the envelope never edits labels)."""
+    env = MessageEnvelope(
+        msg_id=f"msg_{uuid.uuid4().hex[:12]}",
+        from_node=from_node,
+        to_node=to_node,
+        edge_kind=edge_kind,
+        value=value,
+        root=sender.derive_value(value),
+        value_ref=value_ref or f"v_{content_fingerprint(value)[:12]}",
+    )
+    if signer is not None:
+        env = replace(
+            env,
+            signature=signer.sign(env.signed_payload()),
+            algorithm=signer.algorithm,
+        )
+    return env
+
+
+def _root_payload(root: CausalRoot) -> dict:
+    return {
+        "sources": sorted(s.value for s in root.sources),
+        "sensitive": root.sensitive,
+    }
+
+
+class InMemoryMessageBus:
+    """Direct in-process transport for intra-federation edges.
+
+    Transport is irrelevant to semantics (spec v2 Ch.1 §1): the same gate
+    pipeline runs for an in-process hop as for a networked one. The bus emits
+    kernel-schema trace events on both ends via the ``emit`` callback so the
+    platform's topology and the causal-subgraph walk see every hop.
+    """
+
+    def __init__(
+        self,
+        emit: Callable[[Event], None] | None = None,
+        *,
+        verifier_for: Callable[[str], Verifier | None] | None = None,
+    ) -> None:
+        self._emit = emit or (lambda e: None)
+        self._verifier_for = verifier_for
+        self._nodes: dict[str, tuple[TaintEngine, Callable[[], DegradationLevel]]] = {}
+        self._inboxes: dict[str, list[MessageEnvelope]] = {}
+        self._seq: dict[str, int] = {}
+
+    def register(
+        self,
+        node_id: str,
+        taint: TaintEngine,
+        level_of: Callable[[], DegradationLevel] | None = None,
+    ) -> None:
+        self._nodes[node_id] = (taint, level_of or (lambda: DegradationLevel.NORMAL))
+        self._inboxes.setdefault(node_id, [])
+
+    def _next_seq(self, node_id: str) -> int:
+        self._seq[node_id] = self._seq.get(node_id, 0) + 1
+        return self._seq[node_id]
+
+    def _event(
+        self,
+        node_id: str,
+        kind: EventKind,
+        env: MessageEnvelope,
+        verdict: Verdict,
+        *,
+        peer_field: str,
+        gate: str | None = None,
+        reason: str | None = None,
+    ) -> Event:
+        payload = {
+            peer_field: env.to_node if peer_field == "to" else env.from_node,
+            "edge_kind": env.edge_kind,
+            "msg_id": env.msg_id,
+            "value_ref": env.value_ref,
+            "carried": {"root": _root_payload(env.root)},
+        }
+        if reason:
+            payload["reason"] = reason
+        return Event(
+            seq=self._next_seq(node_id),
+            node_id=node_id,
+            kind=kind,
+            ts=f"t:{time.time():.6f}",
+            causal_root=env.value_ref,
+            gate=gate,
+            verdict=verdict,
+            payload=payload,
+        )
+
+    def send(self, env: MessageEnvelope) -> None:
+        """Sender-side gate, then delivery. Raises MessageDenied on a gate
+        deny (containment at the source — the message is never sent)."""
+        if env.edge_kind not in EDGE_KINDS:
+            # Still traced: an attempted send over an undeclared edge is an
+            # event, not a silent no-op.
+            pass
+        _, level_of = self._nodes[env.from_node]
+        deny = evaluate_message_send(level_of(), env.root, env.edge_kind)
+        if deny is not None:
+            self._emit(
+                self._event(
+                    env.from_node, EventKind.MESSAGE_SENT, env, Verdict.DENY,
+                    peer_field="to", gate=deny.category, reason=deny.reason,
+                )
+            )
+            raise MessageDenied(deny)
+        self._emit(
+            self._event(
+                env.from_node, EventKind.MESSAGE_SENT, env, Verdict.PASS,
+                peer_field="to",
+            )
+        )
+        self._deliver(env)
+
+    def _deliver(self, env: MessageEnvelope) -> None:
+        """Receiver side: verify origin (when signed), fold carried labels
+        into the receiver's ledger, record the receipt. Gates on USE of the
+        value run in the receiver's own pipeline — receipt is a source, not a
+        permission."""
+        if env.signature and self._verifier_for is not None:
+            verifier = self._verifier_for(env.from_node)
+            if verifier is None or env.algorithm != verifier.algorithm or (
+                not verifier.verify(env.signed_payload(), env.signature)
+            ):
+                raise MessageRejected(
+                    f"forged or tampered envelope from {env.from_node!r}"
+                )
+        taint, _ = self._nodes[env.to_node]
+        # Monotone fold: a value returning to its origin (cycle A→B→A)
+        # re-mints the union of what it already carried and what it carries
+        # now — the cycle cannot launder (spec v2 Ch.4 open item, resolved
+        # by causal-root identity, not hop count).
+        prior = taint.derive_value(env.value)
+        folded = fold_carried_root(env.root)
+        if prior.is_tainted or prior.sensitive:
+            folded = CausalRoot.mint(prior, folded)
+        taint.register_value(env.value, folded)
+        self._inboxes[env.to_node].append(env)
+        self._emit(
+            self._event(
+                env.to_node, EventKind.MESSAGE_RECEIVED, env, Verdict.PASS,
+                peer_field="from",
+            )
+        )
+
+    def inbox(self, node_id: str) -> list[MessageEnvelope]:
+        return list(self._inboxes.get(node_id, ()))

--- a/axor_core/node/messaging.py
+++ b/axor_core/node/messaging.py
@@ -130,9 +130,13 @@ class InMemoryMessageBus:
         emit: Callable[[Event], None] | None = None,
         *,
         verifier_for: Callable[[str], Verifier | None] | None = None,
+        peer_declared: Callable[[str], bool] | None = None,
     ) -> None:
         self._emit = emit or (lambda e: None)
         self._verifier_for = verifier_for
+        # Which foreign peers are DECLARED in operator config (spec v2 Ch.1
+        # §3): undeclared = L0 = the send gate fails closed on peer edges.
+        self._peer_declared = peer_declared or (lambda peer: False)
         self._nodes: dict[str, tuple[TaintEngine, Callable[[], DegradationLevel]]] = {}
         self._inboxes: dict[str, list[MessageEnvelope]] = {}
         self._seq: dict[str, int] = {}
@@ -189,7 +193,10 @@ class InMemoryMessageBus:
             # event, not a silent no-op.
             pass
         _, level_of = self._nodes[env.from_node]
-        deny = evaluate_message_send(level_of(), env.root, env.edge_kind)
+        deny = evaluate_message_send(
+            level_of(), env.root, env.edge_kind,
+            peer_declared=self._peer_declared(env.to_node),
+        )
         if deny is not None:
             self._emit(
                 self._event(

--- a/axor_core/node/messaging.py
+++ b/axor_core/node/messaging.py
@@ -20,10 +20,17 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 
 from axor_core.contracts.degradation import DegradationLevel
+from axor_core.federation.ladder import (
+    InboundVerdict,
+    LabelAssertion,
+    PeerDeclaration,
+    receive_foreign,
+)
 from axor_core.federation.signing import Signer, Verifier
 from axor_core.kernel.events import Event, EventKind, Verdict
 from axor_core.kernel.messaging import (
     EDGE_KINDS,
+    EDGE_PEER,
     evaluate_message_send,
     fold_carried_root,
 )
@@ -131,12 +138,20 @@ class InMemoryMessageBus:
         *,
         verifier_for: Callable[[str], Verifier | None] | None = None,
         peer_declared: Callable[[str], bool] | None = None,
+        peer_declaration_for: Callable[[str], PeerDeclaration | None] | None = None,
     ) -> None:
         self._emit = emit or (lambda e: None)
         self._verifier_for = verifier_for
         # Which foreign peers are DECLARED in operator config (spec v2 Ch.1
         # §3): undeclared = L0 = the send gate fails closed on peer edges.
-        self._peer_declared = peer_declared or (lambda peer: False)
+        # peer_declaration_for supplies the full declaration for the INBOUND
+        # ladder (receive_foreign); when it is set, peer_declared defaults to
+        # "has a declaration".
+        self._declaration_for = peer_declaration_for or (lambda peer: None)
+        self._peer_declared = peer_declared or (
+            (lambda peer: self._declaration_for(peer) is not None)
+            if peer_declaration_for is not None else (lambda peer: False)
+        )
         self._nodes: dict[str, tuple[TaintEngine, Callable[[], DegradationLevel]]] = {}
         self._inboxes: dict[str, list[MessageEnvelope]] = {}
         self._seq: dict[str, int] = {}
@@ -193,9 +208,14 @@ class InMemoryMessageBus:
             # event, not a silent no-op.
             pass
         _, level_of = self._nodes[env.from_node]
+        # A peer edge is "declared" when its FOREIGN end is declared in our
+        # config — outbound that is the destination, inbound the origin.
         deny = evaluate_message_send(
             level_of(), env.root, env.edge_kind,
-            peer_declared=self._peer_declared(env.to_node),
+            peer_declared=(
+                self._peer_declared(env.to_node)
+                or self._peer_declared(env.from_node)
+            ),
         )
         if deny is not None:
             self._emit(
@@ -227,21 +247,56 @@ class InMemoryMessageBus:
                     f"forged or tampered envelope from {env.from_node!r}"
                 )
         taint, _ = self._nodes[env.to_node]
-        # Monotone fold: a value returning to its origin (cycle A→B→A)
-        # re-mints the union of what it already carried and what it carries
-        # now — the cycle cannot launder (spec v2 Ch.4 open item, resolved
-        # by causal-root identity, not hop count).
+        evidence: tuple[str, ...] = ()
+        if env.edge_kind == EDGE_PEER:
+            # INTER-federation inbound (spec v2 Ch.1 §2): the carried root is
+            # a CLAIM, not data — re-derive through the trust ladder. The
+            # foreign root is kept as an opaque forensic ref in the event
+            # payload; the LOCAL root is what registers.
+            verdict = self._receive_peer(env)
+            folded = verdict.root
+            evidence = verdict.evidence
+        else:
+            # INTRA: labels are data, carried intact. Monotone fold: a value
+            # returning to its origin (cycle A→B→A) re-mints the union of what
+            # it already carried and what it carries now — the cycle cannot
+            # launder (resolved by causal-root identity, not hop count).
+            folded = fold_carried_root(env.root)
         prior = taint.derive_value(env.value)
-        folded = fold_carried_root(env.root)
         if prior.is_tainted or prior.sensitive:
             folded = CausalRoot.mint(prior, folded)
         taint.register_value(env.value, folded)
         self._inboxes[env.to_node].append(env)
-        self._emit(
-            self._event(
-                env.to_node, EventKind.MESSAGE_RECEIVED, env, Verdict.PASS,
-                peer_field="from",
+        received = self._event(
+            env.to_node, EventKind.MESSAGE_RECEIVED, env, Verdict.PASS,
+            peer_field="from",
+        )
+        if env.edge_kind == EDGE_PEER:
+            received.payload["foreign_root"] = _root_payload(env.root)
+            received.payload["local_root"] = _root_payload(folded)
+            if evidence:
+                received.payload["ladder_evidence"] = list(evidence)
+        self._emit(received)
+
+    def _receive_peer(self, env: MessageEnvelope) -> InboundVerdict:
+        declaration = self._declaration_for(env.from_node)
+        assertion: LabelAssertion | None = None
+        if declaration is not None and env.signature:
+            # The envelope's own signature doubles as the L2 label assertion:
+            # it covers identity, edge, value hash AND the labels — exactly
+            # the claim the ladder discounts.
+            assertion = LabelAssertion(
+                peer_id=env.from_node,
+                message_class="default",
+                sources=tuple(sorted(s.value for s in env.root.sources)),
+                sensitive=env.root.sensitive,
+                payload=env.signed_payload(),
+                signature=env.signature,
             )
+        return receive_foreign(
+            value_sensitive_hint=False,
+            declaration=declaration,
+            assertion=assertion,
         )
 
     def inbox(self, node_id: str) -> list[MessageEnvelope]:

--- a/axor_core/node/spawn.py
+++ b/axor_core/node/spawn.py
@@ -8,6 +8,28 @@ from axor_core.contracts.trace import ChildSpawnedEvent, TraceEventKind
 from axor_core.errors.exceptions import ChildNotAllowedError, SpawnValidationError
 from axor_core.node.intent_loop import IntentLoop
 
+
+def inherit_degradation(parent_engine, child_node_id: str):
+    """Per-node degradation at spawn (spec v2 Ch.4 section 3): the child gets a
+    FRESH engine seeded at max(parent level, NORMAL) — a derived posture, not a
+    blank one. Narrow-or-preserve: a CAUTIOUS parent cannot spawn a NORMAL
+    child to escape its own restriction (spawn-laundering, the tree analog of
+    lateral laundering, closed). The child engine is independent afterwards —
+    no shared governance state (decision v2-13)."""
+    from axor_core.contracts.degradation import DegradationLevel
+    from axor_core.degradation.engine import DegradationEngine
+
+    child = DegradationEngine(node_id=child_node_id)
+    parent_level = parent_engine.state.level
+    if parent_level > DegradationLevel.NORMAL:
+        child.tighten(
+            parent_level,
+            reason="spawn inheritance: child starts at parent's level "
+            "(narrow-or-preserve, spec v2 Ch.4)",
+            trigger_intent="spawn",
+        )
+    return child
+
 # ExportMode restrictiveness order — higher index = more restrictive.
 # FILTERED (output+metadata, 4096 tokens) is less restrictive than SUMMARY (output only, 1024 tokens).
 _EXPORT_MODE_ORDER = [ExportMode.FULL, ExportMode.FILTERED, ExportMode.SUMMARY, ExportMode.RESTRICTED]

--- a/axor_core/node/wrapper.py
+++ b/axor_core/node/wrapper.py
@@ -47,6 +47,7 @@ from axor_core.contracts.result import (
     ExecutorEventKind,
     TokenUsage,
 )
+from axor_core.contracts.degradation import DegradationLevel
 from axor_core.contracts.trace import TraceConfig, TraceEventKind
 from axor_core.capability.locked import governance_context
 from axor_core.taint.engine import TaintEngine
@@ -134,6 +135,7 @@ class GovernedNode:
         admission: "AdmissionController | None" = None,
         context_taps: "Sequence | None" = None,
         agent_id: str = "",
+        per_node_degradation: bool = False,
     ) -> None:
         # Optional live-context taps (hot path) so an external monitor
         # (axor-probe) can build drift snapshots. None/empty → the node-level
@@ -155,6 +157,12 @@ class GovernedNode:
         self._escalation_callback = escalation_callback  # None → auto-deny escalation
         self._taint_engine = taint_engine if taint_engine is not None else TaintEngine()
         self._degradation_engine = degradation_engine
+        # Per-node degradation (spec v2 Ch.4 §1/§3): opt-in. False keeps the
+        # v0.13 behavior — one engine shared down the subtree. True gives each
+        # spawned child its OWN engine seeded at max(parent level, NORMAL):
+        # narrow-or-preserve — a CAUTIOUS parent cannot spawn a NORMAL child
+        # to escape its own restriction (spawn-laundering closed).
+        self._per_node_degradation = per_node_degradation
         self._max_intents_per_session = max_intents_per_session
         self._max_total_spawns = max_total_spawns
         self._budget_cap_calls = budget_cap_calls
@@ -545,6 +553,18 @@ class GovernedNode:
         # engine; lateral protection across the node tree is preserved per-value.
         child_taint.inherit_value_ledger(self._taint_engine)
 
+        # Degradation posture at spawn (spec v2 Ch.4 §3). Default: the v0.13
+        # shared engine (subtree lock-down). Opt-in per-node: a FRESH engine
+        # seeded at max(parent level, NORMAL) — the child inherits a derived
+        # posture, not a blank one; spawn narrows or preserves, never widens.
+        child_degradation = self._degradation_engine
+        if self._per_node_degradation and self._degradation_engine is not None:
+            from axor_core.node.spawn import inherit_degradation
+
+            child_degradation = inherit_degradation(
+                self._degradation_engine, child_lineage.node_id
+            )
+
         child_node = GovernedNode(
             executor=self._child_executor or self._executor,
             capability_executor=self._cap_executor,
@@ -558,7 +578,8 @@ class GovernedNode:
             current_depth=self._depth + 1,
             child_executor=self._child_executor,
             escalation_callback=self._escalation_callback,
-            degradation_engine=self._degradation_engine,
+            degradation_engine=child_degradation,
+            per_node_degradation=self._per_node_degradation,
             max_intents_per_session=self._max_intents_per_session,
             max_total_spawns=self._max_total_spawns,
             budget_cap_calls=self._budget_cap_calls,
@@ -585,12 +606,44 @@ class GovernedNode:
         )
 
         child_cancel = envelope.cancel_token.child_token()
-        child_result = await child_node.run(
-            raw_state=child_raw_state,
-            extension_bundle=extension_bundle,
-            parent_policy=parent_policy,
-            cancel_token=child_cancel,
-        )
+        try:
+            child_result = await child_node.run(
+                raw_state=child_raw_state,
+                extension_bundle=extension_bundle,
+                parent_policy=parent_policy,
+                cancel_token=child_cancel,
+            )
+        except Exception as exc:  # noqa: BLE001 — crash/disappearance path
+            # Death by crash (spec v2 Ch.4 §4): a crashed child cannot be
+            # treated as having returned clean — absence is a FACT at the
+            # parent, folded into the degradation recompute. The audit trail
+            # stays intact; cancellation (BaseException) still propagates.
+            from axor_core.contracts.trace import ChildStaleEvent
+
+            stale_child = (
+                child_raw_state.lineage.node_id
+                if child_raw_state.lineage
+                else "unknown"
+            )
+            trace_events.append(
+                ChildStaleEvent(
+                    kind=TraceEventKind.CHILD_STALE,
+                    node_id=envelope.node_id,
+                    sequence=len(trace_events),
+                    payload={
+                        "child_node_id": stale_child,
+                        "error": f"{type(exc).__name__}: {exc}",
+                    },
+                )
+            )
+            if self._degradation_engine is not None:
+                self._degradation_engine.tighten(
+                    DegradationLevel.CAUTIOUS,
+                    reason=f"node_stale: child {stale_child} died without "
+                    f"returning ({type(exc).__name__})",
+                    trigger_intent="spawn",
+                )
+            return f"[child failed: node_stale ({type(exc).__name__})]"
 
         # Provenance of the child's returned output, registered into the parent's
         # per-value ledger so a parent sink later carrying it is gated.

--- a/axor_core/node/wrapper.py
+++ b/axor_core/node/wrapper.py
@@ -47,7 +47,7 @@ from axor_core.contracts.result import (
     ExecutorEventKind,
     TokenUsage,
 )
-from axor_core.contracts.degradation import DegradationLevel
+from axor_core.contracts.degradation import DegradationLevel  # noqa: E402 — house pattern: this import block sits mid-file
 from axor_core.contracts.trace import TraceConfig, TraceEventKind
 from axor_core.capability.locked import governance_context
 from axor_core.taint.engine import TaintEngine

--- a/axor_core/plane/bridge.py
+++ b/axor_core/plane/bridge.py
@@ -18,6 +18,8 @@ from dataclasses import asdict
 
 from axor_core.contracts.trace import (
     CancelledEvent,
+    ChildSpawnedEvent,
+    ChildStaleEvent,
     DegradationTransitionEvent,
     IntentDeniedEvent,
     SourceQuarantinedEvent,
@@ -101,6 +103,48 @@ def trace_event_to_kernel(event: TraceEvent, node_id: str | None = None) -> Even
             gate="anomaly", verdict=Verdict.DENY if denied else Verdict.PASS,
             payload={"tool": event.tool, "score": event.score,
                      "reasons": list(event.reasons)},
+        )
+    if isinstance(event, ChildSpawnedEvent) or event.kind is TraceEventKind.CHILD_SPAWNED:
+        # Tree shape derives from traced spawn events, never from a node
+        # self-reporting its parent (spec v2 Ch.4 §6).
+        d = asdict(event)
+        return Event(
+            seq=seq, node_id=nid, kind=EventKind.NODE_SPAWNED, ts=_ts(seq),
+            payload={
+                "child_id": d.get("child_node_id")
+                or event.payload.get("child_node_id", ""),
+                "parent_id": nid,
+                "depth": d.get("child_depth", event.payload.get("child_depth", 0)),
+                "edge_kind": "delegation",
+            },
+        )
+    if isinstance(event, ChildStaleEvent) or event.kind is TraceEventKind.CHILD_STALE:
+        d = asdict(event)
+        child = d.get("child_node_id") or event.payload.get("child_node_id", "")
+        return Event(
+            seq=seq, node_id=nid, kind=EventKind.FACT, ts=_ts(seq),
+            payload={
+                "fact_id": f"stale_{seq}",
+                "fact_type": "node_stale",
+                "severity": _LEVEL_SEVERITY["CAUTIOUS"],
+                "reason": event.payload.get("error", "child died without returning"),
+                "child_id": child,
+            },
+        )
+    if event.kind is TraceEventKind.CHILD_COMPLETED:
+        # Normal death: the result returns up the spawn edge (message-as-source
+        # at the parent, spec v2 Ch.4 §4). Carried labels ride in the payload
+        # when the recorder provided them.
+        return Event(
+            seq=seq, node_id=nid, kind=EventKind.MESSAGE_RECEIVED, ts=_ts(seq),
+            causal_root=event.payload.get("value_ref"),
+            payload={
+                "from": event.payload.get("child_node_id", ""),
+                "edge_kind": "delegation",
+                "msg_id": f"ret_{seq}",
+                "value_ref": event.payload.get("value_ref"),
+                "carried": event.payload.get("carried", {}),
+            },
         )
     if isinstance(event, CancelledEvent):
         return Event(

--- a/axor_core/worker/session.py
+++ b/axor_core/worker/session.py
@@ -121,6 +121,7 @@ class GovernedSession:
         admission=None,
         session_sink: "SessionSink | None" = None,
         context_taps: "list[ContextTap] | None" = None,
+        per_node_degradation: bool = False,
     ) -> None:
         # Wall-clock the session was constructed — handed to sentinel in the
         # closed-session record (slow-and-low staging compares session start times).
@@ -134,6 +135,9 @@ class GovernedSession:
         # governance hot path — GovernedNode fires node/context_observation on
         # each context build. Observe-only — tap failures are logged, never raised.
         self._context_taps: list[ContextTap] = list(context_taps or [])
+        # Per-node degradation opt-in (spec v2 Ch.4): children get their own
+        # engine seeded at max(parent level, NORMAL) instead of the shared one.
+        self._per_node_degradation = per_node_degradation
 
         # Profile = a named bundle of existing knobs (no new mechanism); it
         # pre-fills mode / isolation / escalation / consequence-ceiling / watcher.
@@ -741,6 +745,7 @@ class GovernedSession:
             admission=self._admission,
             context_taps=self._context_taps or None,
             agent_id=self._agent_def.name if self._agent_def is not None else "",
+            per_node_degradation=self._per_node_degradation,
         )
 
     async def _handle_command(self, raw: str) -> ExecutionResult:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axor-core"
-version = "0.9.1"
+version = "0.9.2"
 description = "Provider-agnostic governance kernel for agent systems"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/federation/test_ladder.py
+++ b/tests/federation/test_ladder.py
@@ -103,3 +103,60 @@ def test_declared_levels_validate() -> None:
 def test_attested_marks_evidence() -> None:
     v = receive_foreign(False, _decl(attested=True), _assert_env(sources=("web",)))
     assert "governance_attested" in v.evidence
+
+
+# ── channel establishment (protocol v0.2 §6a; decisions v2-4/v2-6) ────────────
+
+from axor_core.federation.ladder import (  # noqa: E402
+    ChannelGrant,
+    GovernanceAttestation,
+    establish_channel,
+)
+
+
+def _attestation(forge: bool = False) -> GovernanceAttestation:
+    att = GovernanceAttestation(
+        peer_id="partner", kernel_version="0.9.2",
+        config_hash="sha256:abc", signature=b"",
+    )
+    signer = HmacSigner(shared_key=b"WRONG-key-32-bytes-xxxxxxxxxxxxxx") if forge else SIGNER
+    return GovernanceAttestation(
+        peer_id=att.peer_id, kernel_version=att.kernel_version,
+        config_hash=att.config_hash, signature=signer.sign(att.payload()),
+    )
+
+
+def test_undeclared_channel_pins_l0() -> None:
+    grant = establish_channel(None)
+    assert grant.level == L0 and "undeclared_peer_l0" in grant.evidence
+
+
+def test_mcp_transport_pins_l2_down_to_l1() -> None:
+    grant = establish_channel(_decl(L2), transport="mcp")
+    assert grant.level == L1
+    assert "mcp_transport_pinned_l1" in grant.evidence
+
+
+def test_native_transport_keeps_l2() -> None:
+    assert establish_channel(_decl(L2), transport="native").level == L2
+
+
+def test_valid_attestation_grants_attested_standing() -> None:
+    grant = establish_channel(_decl(L2, attested=True), attestation=_attestation())
+    assert grant.governance_attested is True
+    assert grant.config_hash == "sha256:abc"
+    assert "governance_attestation_verified" in grant.evidence
+
+
+def test_forged_attestation_is_evidenced_not_attested() -> None:
+    grant = establish_channel(
+        _decl(L2, attested=True), attestation=_attestation(forge=True)
+    )
+    assert grant.governance_attested is False and grant.config_hash is None
+    assert "governance_attestation_failed" in grant.evidence
+
+
+def test_missing_attestation_for_attested_declaration_is_evidenced() -> None:
+    grant = establish_channel(_decl(L2, attested=True))
+    assert grant.governance_attested is False
+    assert "governance_attestation_failed" in grant.evidence

--- a/tests/federation/test_ladder.py
+++ b/tests/federation/test_ladder.py
@@ -1,0 +1,105 @@
+"""Inter-federation trust ladder (spec v2 Ch.1 §2): declaration buys discount,
+never label authority; forgery falls to L0 evidenced; critical sinks ignore
+discounts."""
+from __future__ import annotations
+
+import pytest
+from axor_core.contracts.taint import TaintSource
+from axor_core.federation.ladder import (
+    L0,
+    L1,
+    L2,
+    LabelAssertion,
+    PeerDeclaration,
+    effective_root_for_sink,
+    receive_foreign,
+)
+from axor_core.federation.signing import HmacSigner
+
+KEY = b"peer-shared-key-32-bytes-xxxxxxx" + b"x"
+SIGNER = HmacSigner(shared_key=KEY)
+
+
+def _assert_env(message_class: str = "research", sources: tuple = (),
+                sensitive: bool = False, forge: bool = False) -> LabelAssertion:
+    payload = f"{message_class}:{sources}:{sensitive}".encode()
+    sig = HmacSigner(shared_key=b"WRONG-key-32-bytes-xxxxxxxxxxxxxx").sign(payload) \
+        if forge else SIGNER.sign(payload)
+    return LabelAssertion(
+        peer_id="partner", message_class=message_class,
+        sources=sources, sensitive=sensitive, payload=payload, signature=sig,
+    )
+
+
+def _decl(level: str = L2, classes: tuple = ("research",), attested: bool = False) -> PeerDeclaration:
+    return PeerDeclaration(
+        peer_id="partner", level=level,
+        verifier=SIGNER if level != L0 else None,
+        discount_classes=frozenset(classes),
+        governance_attested=attested,
+    )
+
+
+def test_undeclared_peer_is_l0_full_taint() -> None:
+    v = receive_foreign(False, None)
+    assert v.level == L0 and v.root.is_tainted and not v.discounted
+    assert "undeclared_peer_l0" in v.evidence
+
+
+def test_l1_buys_attribution_not_trust() -> None:
+    v = receive_foreign(False, _decl(L1, ()), _assert_env(sources=()))
+    assert v.level == L1 and v.root.is_tainted and not v.discounted
+
+
+def test_l2_discount_is_bounded_never_clean() -> None:
+    # peer asserts "clean" — the discount can NEVER reach clean
+    v = receive_foreign(False, _decl(), _assert_env(sources=()))
+    assert v.discounted and v.root.is_tainted
+    assert TaintSource.UNKNOWN_EXTERNAL in v.root.sources
+
+
+def test_l2_discount_accepts_asserted_sources_as_evidence() -> None:
+    v = receive_foreign(False, _decl(), _assert_env(sources=("web",)))
+    assert v.discounted
+    assert v.root.sources == frozenset({TaintSource.WEB})
+    assert v.root.is_tainted  # narrower label, still tainted
+
+
+def test_discount_only_for_declared_message_classes() -> None:
+    v = receive_foreign(False, _decl(classes=("billing",)), _assert_env("research"))
+    assert not v.discounted and v.root.is_tainted
+    assert any("class_not_discounted" in e for e in v.evidence)
+
+
+def test_forged_assertion_falls_to_l0_evidenced() -> None:
+    v = receive_foreign(False, _decl(), _assert_env(forge=True))
+    assert v.level == L0 and not v.discounted and v.root.is_tainted
+    assert any("assertion_forged_fell_to_l0" in e for e in v.evidence)
+
+
+def test_peer_cannot_clear_our_sensitivity_hint() -> None:
+    # never affecting the confidentiality floor: sensitive=False from the peer
+    # does not clear OUR channel-level sensitivity knowledge
+    v = receive_foreign(True, _decl(), _assert_env(sources=("web",), sensitive=False))
+    assert v.root.sensitive is True and v.full_root.sensitive is True
+
+
+def test_critical_sink_ignores_discount() -> None:
+    v = receive_foreign(False, _decl(), _assert_env(sources=("web",)))
+    assert v.discounted
+    critical = effective_root_for_sink(v, sink_is_critical=True)
+    standard = effective_root_for_sink(v, sink_is_critical=False)
+    assert critical == v.full_root  # undiscounted — criticality non-negotiable
+    assert standard == v.root
+
+
+def test_declared_levels_validate() -> None:
+    with pytest.raises(ValueError):
+        PeerDeclaration(peer_id="p", level="l3")
+    with pytest.raises(ValueError):
+        PeerDeclaration(peer_id="p", level=L2, verifier=None)
+
+
+def test_attested_marks_evidence() -> None:
+    v = receive_foreign(False, _decl(attested=True), _assert_env(sources=("web",)))
+    assert "governance_attested" in v.evidence

--- a/tests/kernel/test_messaging.py
+++ b/tests/kernel/test_messaging.py
@@ -1,0 +1,207 @@
+"""Kernel messaging: pure boundary-gate predicates and the multi-node fold.
+
+Spec v2 Ch.4 — labels ride in envelopes, gates run locally on both edge ends,
+no shared state; Ch.1 §1 — intra-federation labels are data, carried intact;
+hop count cleans nothing.
+"""
+from __future__ import annotations
+
+import json
+
+from axor_core.contracts.degradation import DegradationLevel
+from axor_core.kernel.events import Event, EventKind, Verdict, event_from_json_line
+from axor_core.kernel.messaging import (
+    EDGE_LATERAL,
+    EDGE_PEER,
+    evaluate_message_send,
+    fold_carried_root,
+)
+from axor_core.kernel.replay import KernelConfig, replay, replay_tree
+from axor_core.taint.causal_root import CausalRoot
+
+# ── send gate ──────────────────────────────────────────────────────────────────
+
+
+def test_send_passes_for_normal_lateral() -> None:
+    assert evaluate_message_send(
+        DegradationLevel.NORMAL, CausalRoot.cross_process_in(), EDGE_LATERAL
+    ) is None
+
+
+def test_send_carries_taint_instead_of_denying_intra() -> None:
+    # Intra edges carry labels; a tainted value may travel — it denies at the
+    # sink that matters, not at the internal hop (carried, not laundered).
+    assert evaluate_message_send(
+        DegradationLevel.CAUTIOUS, CausalRoot.cross_process_in(), EDGE_LATERAL
+    ) is None
+
+
+def test_send_denied_at_locked() -> None:
+    deny = evaluate_message_send(
+        DegradationLevel.LOCKED, CausalRoot.constant(), EDGE_LATERAL
+    )
+    assert deny is not None and deny.category == "degradation"
+
+
+def test_send_denied_unknown_edge_kind() -> None:
+    deny = evaluate_message_send(
+        DegradationLevel.NORMAL, CausalRoot.constant(), "carrier-pigeon"
+    )
+    assert deny is not None and deny.category == "message_gate"
+
+
+def test_send_denied_undeclared_peer_fail_closed() -> None:
+    deny = evaluate_message_send(
+        DegradationLevel.NORMAL, CausalRoot.constant(), EDGE_PEER
+    )
+    assert deny is not None and "undeclared" in deny.reason
+
+
+def test_send_declared_peer_passes_the_base_predicate() -> None:
+    assert evaluate_message_send(
+        DegradationLevel.NORMAL, CausalRoot.constant(), EDGE_PEER,
+        peer_declared=True,
+    ) is None
+
+
+# ── carried-root fold ──────────────────────────────────────────────────────────
+
+
+def test_fold_missing_root_fails_closed_to_untrusted() -> None:
+    folded = fold_carried_root(None)
+    assert folded.is_tainted and not folded.sensitive
+
+
+def test_fold_carried_root_arrives_intact() -> None:
+    root = CausalRoot.cross_process_in()
+    assert fold_carried_root(root) is root
+
+
+# ── multi-node fold (replay) ───────────────────────────────────────────────────
+
+
+def _ev(seq: int, node: str, kind: str, **payload) -> Event:
+    verdict = payload.pop("verdict", None)
+    return Event(
+        seq=seq, node_id=node, kind=EventKind(kind), ts=f"seq:{seq}",
+        verdict=Verdict(verdict) if verdict else None, payload=payload,
+    )
+
+
+def _tree_events() -> list[Event]:
+    """scraper (fault, tainted result) → researcher (lateral) → orchestrator;
+    orchestrator's export drives off the carried ref."""
+    return [
+        # scraper: a web-tainted tool result
+        _ev(0, "scraper", "tool_call", verdict="pass", tool="web_search", args={}),
+        _ev(1, "scraper", "tool_result", tool="web_search", value_ref="v_fab",
+            root={"sources": ["web"], "sensitive": False}),
+        _ev(2, "scraper", "message_sent", verdict="pass", to="researcher",
+            edge_kind="lateral", msg_id="m1", value_ref="v_fab",
+            carried={"root": {"sources": ["web"], "sensitive": False}}),
+        # researcher: receives, folds carried taint, forwards
+        _ev(0, "researcher", "message_received", **{"from": "scraper"},
+            edge_kind="lateral", msg_id="m1", value_ref="v_fab",
+            carried={"root": {"sources": ["web"], "sensitive": False}}),
+        _ev(1, "researcher", "message_sent", verdict="pass", to="orch",
+            edge_kind="delegation", msg_id="m2", value_ref="v_fab",
+            carried={"root": {"sources": ["web"], "sensitive": False}}),
+        # orchestrator: receives, then tries to export the carried value
+        _ev(0, "orch", "message_received", **{"from": "researcher"},
+            edge_kind="delegation", msg_id="m2", value_ref="v_fab",
+            carried={"root": {"sources": ["web"], "sensitive": False}}),
+        _ev(1, "orch", "tool_call", verdict="pass", tool="slack_post",
+            args={"text": "…"}, arg_refs={"text": "v_fab"},
+            normalized={"destination_kind": "external_domain"}),
+    ]
+
+
+def test_message_received_folds_carried_taint() -> None:
+    per_node = replay_tree(_tree_events())
+    for node in ("scraper", "researcher", "orch"):
+        final = per_node[node].steps[-1].state
+        assert "v_fab" in final.tainted_refs, f"{node} lost the carried taint"
+        assert final.tainted_refs["v_fab"].is_tainted
+
+
+def test_carried_taint_denies_export_under_config() -> None:
+    """Containment, kernel-grounded: the orchestrator's export re-gates to
+    DENY because its driving ref carries the taint minted two nodes away."""
+    config = KernelConfig(egress_sinks=frozenset({"slack_post"}))
+    per_node = replay_tree(_tree_events(), config)
+    export_step = per_node["orch"].steps[-1]
+    assert export_step.reevaluated_verdict is Verdict.DENY
+    assert export_step.deny is not None
+    assert export_step.deny.category == "taint_enforcement"
+
+
+def test_sensitive_carried_root_arms_receiver_floor() -> None:
+    events = [
+        _ev(0, "b", "message_received", **{"from": "a"}, edge_kind="lateral",
+            msg_id="m", value_ref="v_sec",
+            carried={"root": {"sources": ["file"], "sensitive": True}}),
+    ]
+    result = replay(events)
+    assert result.steps[-1].state.floor_active is True
+
+
+def test_message_without_carried_root_folds_untrusted() -> None:
+    events = [
+        _ev(0, "b", "message_received", **{"from": "a"}, edge_kind="lateral",
+            msg_id="m", value_ref="v_x", carried={}),
+    ]
+    result = replay(events)
+    assert result.steps[-1].state.tainted_refs["v_x"].is_tainted
+
+
+def test_cycle_refolds_monotonically() -> None:
+    """A→B→A: the value returns to its origin; labels re-fold by union — the
+    cycle cannot launder, taint only accumulates (Ch.4 open item)."""
+    events = [
+        _ev(0, "a", "tool_result", tool="t", value_ref="v_c",
+            root={"sources": ["web"], "sensitive": False}),
+        _ev(1, "a", "message_received", **{"from": "b"}, edge_kind="lateral",
+            msg_id="m2", value_ref="v_c",
+            carried={"root": {"sources": [], "sensitive": False}}),
+    ]
+    result = replay(events)
+    final = result.steps[-1].state
+    # The returning "clean" claim did not wash the existing web taint.
+    assert final.tainted_refs["v_c"].is_tainted
+
+
+def test_replay_tree_size1_is_exactly_replay() -> None:
+    """The size-1 degeneracy (spec v2 header): one node, no edges — identical
+    result to the v0.13 single-trace fold."""
+    single = [
+        _ev(0, "solo", "tool_call", verdict="pass", tool="read", args={}),
+        _ev(1, "solo", "tool_result", tool="read", value_ref="v_1",
+            root={"sources": ["web"], "sensitive": False}),
+    ]
+    tree = replay_tree(single)
+    flat = replay(single)
+    assert list(tree.keys()) == ["solo"]
+    assert tree["solo"] == flat
+
+
+def test_tree_fold_is_deterministic() -> None:
+    a = replay_tree(_tree_events(), KernelConfig(egress_sinks=frozenset({"slack_post"})))
+    b = replay_tree(_tree_events(), KernelConfig(egress_sinks=frozenset({"slack_post"})))
+    assert a == b
+
+
+def test_events_round_trip_json() -> None:
+    for e in _tree_events():
+        from axor_core.kernel.events import event_to_json_line
+
+        assert event_from_json_line(event_to_json_line(e)) == e
+
+
+def test_node_spawned_folds_as_structure_only() -> None:
+    events = [
+        _ev(0, "parent", "node_spawned", child_id="c1", parent_id="parent",
+            depth=1, edge_kind="delegation"),
+    ]
+    result = replay(events)
+    s = result.steps[-1].state
+    assert not s.tainted_refs and s.level is DegradationLevel.NORMAL

--- a/tests/kernel/test_subgraph.py
+++ b/tests/kernel/test_subgraph.py
@@ -1,0 +1,101 @@
+"""The causal-subgraph walk (spec v2 Ch.3): minimal causes, roles, anchoring,
+containment, size-1 degeneracy."""
+from __future__ import annotations
+
+import pytest
+from axor_core.kernel.events import Event, EventKind, Verdict
+from axor_core.kernel.subgraph import causal_subgraph
+
+
+def _ev(seq: int, node: str, kind: str, **payload) -> Event:
+    verdict = payload.pop("verdict", None)
+    gate = payload.pop("gate", None)
+    return Event(
+        seq=seq, node_id=node, kind=EventKind(kind), ts=f"seq:{seq}",
+        gate=gate, verdict=Verdict(verdict) if verdict else None, payload=payload,
+    )
+
+
+WEB = {"root": {"sources": ["web"], "sensitive": False}}
+
+
+def _tree() -> list[Event]:
+    """The demo story: fault at scraper → fabrication carried up two hops →
+    export denied at the orchestrator. Plus an UNRELATED fourth node."""
+    return [
+        _ev(0, "scraper", "fault_injected", tool="web_search", mode="silent_fail"),
+        _ev(1, "scraper", "tool_call", verdict="pass", tool="web_search",
+            args={}, arg_refs={}),
+        _ev(2, "scraper", "tool_result", tool="web_search", value_ref="v_fab",
+            root=WEB["root"]),
+        _ev(3, "scraper", "message_sent", verdict="pass", to="research",
+            edge_kind="delegation", msg_id="m1", value_ref="v_fab", carried=WEB),
+        _ev(0, "research", "message_received", **{"from": "scraper"},
+            edge_kind="delegation", msg_id="m1", value_ref="v_fab", carried=WEB),
+        _ev(1, "research", "tool_call", verdict="pass", tool="summarize",
+            args={}, arg_refs={"text": "v_fab"}),
+        _ev(2, "research", "tool_result", tool="summarize", value_ref="v_sum",
+            root=WEB["root"]),
+        _ev(3, "research", "message_sent", verdict="pass", to="orch",
+            edge_kind="delegation", msg_id="m2", value_ref="v_sum", carried=WEB),
+        _ev(0, "orch", "message_received", **{"from": "research"},
+            edge_kind="delegation", msg_id="m2", value_ref="v_sum", carried=WEB),
+        _ev(1, "orch", "tool_call", verdict="deny", gate="taint_enforcement",
+            tool="slack_post", args={}, arg_refs={"text": "v_sum"}),
+        # unrelated node — must NOT appear in the case
+        _ev(0, "writer", "tool_call", verdict="pass", tool="format", args={}),
+    ]
+
+
+def test_walk_finds_the_three_causal_nodes_not_the_org_chart() -> None:
+    sub = causal_subgraph(_tree(), "orch", 1)
+    ids = {n["node_id"] for n in sub["nodes"]}
+    assert ids == {"scraper", "research", "orch"}  # writer excluded
+
+
+def test_roles() -> None:
+    sub = causal_subgraph(_tree(), "orch", 1)
+    roles = {n["node_id"]: set(n["roles"]) for n in sub["nodes"]}
+    assert "origin" in roles["scraper"]
+    assert "conduit" in roles["research"]
+    assert {"anchor", "container"} <= roles["orch"]  # denied at the anchor
+
+
+def test_fault_origin_and_containment() -> None:
+    sub = causal_subgraph(_tree(), "orch", 1)
+    assert sub["fault_origin"] == {"node_id": "scraper", "seq": 0}
+    assert sub["contained_at"] and sub["contained_at"][0]["gate"] == "taint_enforcement"
+    assert sub["federation_scope"] == "intra"
+
+
+def test_edges_are_the_message_hops_with_carried_labels() -> None:
+    sub = causal_subgraph(_tree(), "orch", 1)
+    hops = {(e["from"], e["to"]) for e in sub["edges"]}
+    assert hops == {("scraper", "research"), ("research", "orch")}
+    assert all(e["carried"]["root"]["sources"] == ["web"] for e in sub["edges"])
+    assert all(e["gate_verdict"] == "pass" for e in sub["edges"])
+
+
+def test_size1_degenerates_to_anchor_only() -> None:
+    """One node, no edges — exactly the v0.13 case; renderers branch on size."""
+    events = [
+        _ev(0, "solo", "fault_injected", tool="web_search", mode="silent_fail"),
+        _ev(1, "solo", "tool_call", verdict="pass", tool="web_search",
+            args={}, arg_refs={}),
+        _ev(2, "solo", "tool_result", tool="web_search", value_ref="v_f",
+            root=WEB["root"]),
+        _ev(3, "solo", "claim", text="all good"),
+    ]
+    sub = causal_subgraph(events, "solo", 3)
+    assert [n["node_id"] for n in sub["nodes"]] == ["solo"]
+    assert sub["edges"] == []
+    assert sub["federation_scope"] == "intra"
+
+
+def test_missing_anchor_raises() -> None:
+    with pytest.raises(ValueError):
+        causal_subgraph(_tree(), "orch", 99)
+
+
+def test_deterministic() -> None:
+    assert causal_subgraph(_tree(), "orch", 1) == causal_subgraph(_tree(), "orch", 1)

--- a/tests/node/test_message_bus.py
+++ b/tests/node/test_message_bus.py
@@ -184,3 +184,71 @@ def test_declared_peer_edge_passes_the_send_gate() -> None:
     bus.send(make_envelope(eng, "a", "partner", "peer", "hello"))
     sent = [e for e in events if e.kind is EventKind.MESSAGE_SENT][-1]
     assert sent.verdict is Verdict.PASS
+
+
+# ── inter-federation inbound: the ladder in the live path (spec v2 Ch.1 §2) ───
+
+
+def _peer_bus(level: str, *, key: bytes = b"fed-key-32-bytes-long-xxxxxxxxxx"):
+    from axor_core.federation.ladder import L2, PeerDeclaration
+
+    events: list[Event] = []
+    decl = PeerDeclaration(
+        peer_id="partner", level=level,
+        verifier=HmacSigner(shared_key=key),
+        discount_classes=frozenset({"default"}) if level == L2 else frozenset(),
+    )
+    bus = InMemoryMessageBus(
+        emit=events.append,
+        peer_declaration_for=lambda p: decl if p == "partner" else None,
+    )
+    ours = TaintEngine(node_id="ours")
+    theirs = TaintEngine(node_id="partner")
+    bus.register("ours", ours)
+    bus.register("partner", theirs)
+    return bus, ours, theirs, events
+
+
+def test_peer_inbound_l1_remints_despite_clean_claim() -> None:
+    """The peer asserts 'clean'; at L1 that is attribution, not trust — the
+    value registers TAINTED locally (labels are claims across keysets)."""
+    from axor_core.federation.ladder import L1
+
+    bus, ours, theirs, events = _peer_bus(L1)
+    value = "their report"
+    env = make_envelope(theirs, "partner", "ours", "peer", value)  # clean at sender
+    bus.send(env)
+    assert ours.derive_value(value).is_tainted
+    received = [e for e in events if e.kind is EventKind.MESSAGE_RECEIVED][-1]
+    # the foreign root survives as an opaque forensic ref; the local root is minted
+    assert received.payload["foreign_root"]["sources"] == []
+    assert received.payload["local_root"]["sources"] != []
+
+
+def test_peer_inbound_l2_signed_assertion_discounts_never_clean() -> None:
+    from axor_core.federation.ladder import L2
+
+    signer = HmacSigner(shared_key=b"fed-key-32-bytes-long-xxxxxxxxxx")
+    bus, ours, theirs, events = _peer_bus(L2)
+    value = "their web summary"
+    theirs.register_value(value, CausalRoot.cross_process_in())
+    env = make_envelope(theirs, "partner", "ours", "peer", value, signer=signer)
+    bus.send(env)
+    root = ours.derive_value(value)
+    assert root.is_tainted  # discounted is still tainted — never to clean
+    received = [e for e in events if e.kind is EventKind.MESSAGE_RECEIVED][-1]
+    assert "l2_discount_applied" in received.payload["ladder_evidence"]
+
+
+def test_peer_inbound_forged_assertion_falls_to_l0_evidenced() -> None:
+    from axor_core.federation.ladder import L2
+
+    bus, ours, theirs, events = _peer_bus(L2)
+    value = "forged-labels value"
+    env = make_envelope(theirs, "partner", "ours", "peer", value,
+                        signer=HmacSigner(shared_key=b"WRONG-key-32-bytes-xxxxxxxxxxxxxx"))
+    bus.send(env)
+    assert ours.derive_value(value).is_tainted  # L0 handling: full re-mint
+    received = [e for e in events if e.kind is EventKind.MESSAGE_RECEIVED][-1]
+    assert any("assertion_forged_fell_to_l0" in e
+               for e in received.payload["ladder_evidence"])

--- a/tests/node/test_message_bus.py
+++ b/tests/node/test_message_bus.py
@@ -172,3 +172,15 @@ async def test_child_crash_is_a_fact_not_a_clean_return() -> None:
     assert stale, "child crash must leave a CHILD_STALE trace event"
     assert sess._degradation_engine.state.level >= DegradationLevel.CAUTIOUS
     assert "node_stale" in (result.output or "")
+
+
+def test_declared_peer_edge_passes_the_send_gate() -> None:
+    events: list[Event] = []
+    bus = InMemoryMessageBus(emit=events.append,
+                             peer_declared=lambda p: p == "partner")
+    eng = TaintEngine(node_id="a")
+    bus.register("a", eng)
+    bus.register("partner", TaintEngine(node_id="partner"))
+    bus.send(make_envelope(eng, "a", "partner", "peer", "hello"))
+    sent = [e for e in events if e.kind is EventKind.MESSAGE_SENT][-1]
+    assert sent.verdict is Verdict.PASS

--- a/tests/node/test_message_bus.py
+++ b/tests/node/test_message_bus.py
@@ -1,0 +1,174 @@
+"""Runtime messaging: envelopes with labels, the in-memory bus, signing,
+spawn-level inheritance, and the node_stale death path.
+
+Spec v2 Ch.4 — orchestration around the pure kernel, zero governance logic in
+the orchestration; Ch.1 §1 — transport is irrelevant to semantics.
+"""
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+import pytest
+from axor_core import GovernedSession, presets
+from axor_core.contracts.degradation import DegradationLevel
+from axor_core.contracts.invokable import Invokable
+from axor_core.contracts.result import ExecutorEvent, ExecutorEventKind
+from axor_core.contracts.trace import TraceConfig, TraceEventKind
+from axor_core.degradation.engine import DegradationEngine
+from axor_core.federation.signing import HmacSigner
+from axor_core.kernel.events import Event, EventKind, Verdict
+from axor_core.node.messaging import (
+    InMemoryMessageBus,
+    MessageDenied,
+    MessageRejected,
+    make_envelope,
+)
+from axor_core.node.spawn import inherit_degradation
+from axor_core.taint.causal_root import CausalRoot
+from axor_core.taint.engine import TaintEngine
+from tests.conftest import EchoExecutor
+
+
+def _bus_with(*nodes: str, **kw) -> tuple[InMemoryMessageBus, dict[str, TaintEngine], list[Event]]:
+    events: list[Event] = []
+    bus = InMemoryMessageBus(emit=events.append, **kw)
+    engines = {}
+    for n in nodes:
+        engines[n] = TaintEngine(node_id=n)
+        bus.register(n, engines[n])
+    return bus, engines, events
+
+
+def test_carried_not_laundered() -> None:
+    """A tainted value crossing a lateral edge arrives still tainted at the
+    sibling — one hop through a sibling washes nothing."""
+    bus, eng, events = _bus_with("a", "b")
+    value = "fabricated result"
+    eng["a"].register_value(value, CausalRoot.cross_process_in())
+
+    env = make_envelope(eng["a"], "a", "b", "lateral", value)
+    bus.send(env)
+
+    assert eng["b"].derive_value(value).is_tainted
+    kinds = [(e.node_id, e.kind, e.verdict) for e in events]
+    assert ("a", EventKind.MESSAGE_SENT, Verdict.PASS) in kinds
+    assert ("b", EventKind.MESSAGE_RECEIVED, Verdict.PASS) in kinds
+
+
+def test_clean_value_stays_clean_intra() -> None:
+    """The envelope never edits labels: a clean value crosses clean (per-value
+    fidelity is the intra win — no blanket re-mint inside one federation)."""
+    bus, eng, _ = _bus_with("a", "b")
+    value = "constant text"
+    env = make_envelope(eng["a"], "a", "b", "lateral", value)
+    bus.send(env)
+    root = eng["b"].derive_value(value)
+    assert not root.is_tainted and not root.sensitive
+
+
+def test_sensitive_value_arms_receiver_floor() -> None:
+    bus, eng, _ = _bus_with("a", "b")
+    secret = "API_KEY_123456789"
+    eng["a"].register_value(secret, CausalRoot(sources=frozenset(), sensitive=True))
+    bus.send(make_envelope(eng["a"], "a", "b", "lateral", secret))
+    assert eng["b"].confidentiality_floor_active() is True
+
+
+def test_locked_sender_denied_and_traced() -> None:
+    bus, eng, events = _bus_with("a", "b")
+    bus.register("a", eng["a"], level_of=lambda: DegradationLevel.LOCKED)
+    with pytest.raises(MessageDenied):
+        bus.send(make_envelope(eng["a"], "a", "b", "lateral", "x"))
+    deny = [e for e in events if e.kind is EventKind.MESSAGE_SENT][-1]
+    assert deny.verdict is Verdict.DENY and deny.gate == "degradation"
+    assert bus.inbox("b") == []  # containment at the source: never delivered
+
+
+def test_undeclared_peer_edge_denied() -> None:
+    bus, eng, _ = _bus_with("a", "b")
+    with pytest.raises(MessageDenied):
+        bus.send(make_envelope(eng["a"], "a", "b", "peer", "x"))
+
+
+def test_cycle_cannot_launder() -> None:
+    """A→B→A: after the round trip the origin still sees the taint (monotone
+    re-fold by causal-root identity, not hop count)."""
+    bus, eng, _ = _bus_with("a", "b")
+    value = "poisoned doc"
+    eng["a"].register_value(value, CausalRoot.cross_process_in())
+    bus.send(make_envelope(eng["a"], "a", "b", "lateral", value))
+    bus.send(make_envelope(eng["b"], "b", "a", "lateral", value))
+    assert eng["a"].derive_value(value).is_tainted
+
+
+def test_signed_envelope_verifies_and_tamper_rejects() -> None:
+    signer = HmacSigner(shared_key=b"fed-key-32-bytes-long-xxxxxxxxxx")
+    bus, eng, _ = _bus_with(
+        "a", "b", verifier_for=lambda peer: HmacSigner(shared_key=b"fed-key-32-bytes-long-xxxxxxxxxx")
+    )
+    env = make_envelope(eng["a"], "a", "b", "lateral", "v", signer=signer)
+    bus.send(env)  # valid signature → delivered
+    assert len(bus.inbox("b")) == 1
+
+    forged = make_envelope(eng["a"], "a", "b", "lateral", "v2",
+                           signer=HmacSigner(shared_key=b"wrong-key-32-bytes-long-xxxxxxxxx"))
+    with pytest.raises(MessageRejected):
+        bus.send(forged)
+
+
+# ── spawn inheritance (spec v2 Ch.4 §3) ────────────────────────────────────────
+
+
+def test_child_inherits_parent_level_narrow_or_preserve() -> None:
+    parent = DegradationEngine(node_id="p")
+    parent.tighten(DegradationLevel.CAUTIOUS, reason="test", trigger_intent="t")
+    child = inherit_degradation(parent, "c")
+    assert child.state.level is DegradationLevel.CAUTIOUS
+    assert child is not parent  # own engine — no shared governance state
+
+
+def test_child_of_normal_parent_starts_normal() -> None:
+    parent = DegradationEngine(node_id="p")
+    child = inherit_degradation(parent, "c")
+    assert child.state.level is DegradationLevel.NORMAL
+
+
+def test_child_engine_is_independent_after_spawn() -> None:
+    parent = DegradationEngine(node_id="p")
+    child = inherit_degradation(parent, "c")
+    child.tighten(DegradationLevel.RESTRICTED, reason="child fault",
+                  trigger_intent="t")
+    assert parent.state.level is DegradationLevel.NORMAL  # no upward bleed
+
+
+# ── death: node_stale (spec v2 Ch.4 §4) ────────────────────────────────────────
+
+
+class _CrashingChild(Invokable):
+    async def stream(self, envelope) -> AsyncIterator[ExecutorEvent]:
+        raise RuntimeError("child process disappeared")
+        yield  # pragma: no cover
+
+
+@pytest.mark.asyncio
+async def test_child_crash_is_a_fact_not_a_clean_return() -> None:
+    parent = EchoExecutor(tool_calls=[("spawn_child", {"task": "doomed"})])
+    sess = GovernedSession(
+        executor=parent,
+        capability_executor=__import__(
+            "axor_core.capability.executor", fromlist=["CapabilityExecutor"]
+        ).CapabilityExecutor(),
+        child_executor=_CrashingChild(),
+        trace_config=TraceConfig(local_only=True, persist_inputs=False),
+    )
+    result = await sess.run("delegate", policy=presets.get("federated"))
+    # The parent survived; the child's absence is recorded, not silently clean.
+    stale = [
+        e
+        for trace in sess.all_traces()
+        for e in getattr(trace, "events", [])
+        if getattr(e, "kind", None) is TraceEventKind.CHILD_STALE
+    ]
+    assert stale, "child crash must leave a CHILD_STALE trace event"
+    assert sess._degradation_engine.state.level >= DegradationLevel.CAUTIOUS
+    assert "node_stale" in (result.output or "")

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "axor-core"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Implements the axor-core side of spec v2 (multi-agent). Additive only: a single node is a tree with no edges — the 0.9.1 suite passes unmodified, and the platform's size-1 golden gate pins byte-identical single-agent behavior end-to-end.

## Runtime (Ch.4)
- **Kernel messaging**: new event kinds `NODE_SPAWNED` / `MESSAGE_SENT` / `MESSAGE_RECEIVED`; pure send gate `evaluate_message_send` (LOCKED admits no sends, undeclared peer edges fail closed) and `fold_carried_root` (a message that lost its labels re-mints untrusted). `replay()` folds carried labels intact and monotonically on cycles (A→B→A cannot launder); `replay_tree()` folds a multi-node trace per node — no shared governance state (v2-13); size-1 degenerates to exactly `replay()`.
- **Runtime messaging** (`node/messaging.py`): `MessageEnvelope` — labels ride with the value, federation-key signable, tamper → rejected; `InMemoryMessageBus` emits kernel events on both edge ends; a sender-side deny is containment at the source.
- **Spawn**: `inherit_degradation` — opt-in per-node degradation (`per_node_degradation`), child seeded at max(parent level, NORMAL) — spawn-laundering closed. Default keeps the v0.13 shared-engine behavior.
- **Death**: a crashed child leaves a `CHILD_STALE` trace event and tightens the parent to CAUTIOUS (bridged to kernel FACT `node_stale`) — absence is a fact, never a clean return.
- **Bridge**: `CHILD_SPAWNED` → `NODE_SPAWNED`, `CHILD_COMPLETED` → `MESSAGE_RECEIVED` (delegation), `CHILD_STALE` → FACT.

## Inter-federation (Ch.1)
- **Trust ladder** (`federation/ladder.py`): `PeerDeclaration` (undeclared = L0), `receive_foreign` — L0 full taint / L1 attribution-only / L2 bounded discount **never to clean**, floor never peer-negotiable; forged assertion **falls to L0 evidenced**; `effective_root_for_sink` — critical sinks ignore discounts entirely (v2-3); `establish_channel` — MCP-as-A2A pinned L0/L1 (v2-4), governance attestation (signed kernel+config-hash) verified at establishment, failures evidenced (v2-6).
- The gateway restore path is documented as intra-keyset-only (the v2-1/v2-2 semantic alignment); peer-edge delivery in the bus re-derives through the ladder, keeping the foreign root as an opaque forensic ref beside the minted local root.

## EvidenceCase core (Ch.3)
- `kernel/subgraph.py`: backward provenance walk from an anchored claim/denial — minimal causes, roles (origin/conduit/container/anchor), `fault_origin`, `contained_at`, `federation_scope`; message hops become subgraph edges with carried labels; size-1 degenerates to anchor-only.

## Release
- Version 0.9.2 (single-sourced via `_version.py`), changelog stamped. The platform pins `>=0.9.2,<0.10` — **publish to PyPI after merge** so the platform can regenerate its lock.

Tests: **1025 passed** (970 baseline unmodified + 55 new), lint delta clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NSyuJG3mwrGxE9guwasBb

---
_Generated by [Claude Code](https://claude.ai/code/session_016NSyuJG3mwrGxE9guwasBb)_