### PR TITLE
Legacy-path guards: fail-safe classifier boundary, operator escalation ceiling, fail-closed ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,13 +238,18 @@ session = GovernedSession(
     executor=..., capability_executor=...,
     # Guard 1 — approve mid-run capability escalations (fail-closed without it):
     escalation_callback=AllowlistEscalationApprover(
-        {"bash": 10, "write": 20}, allowed_path_prefixes=("/workspace",),
+        {"bash": 10, "write": 20},
+        allowed_path_prefixes=("/workspace",),  # confines path-bearing grants (write)
+        unconfined_tools=("bash",),             # bash calls expose no checkable path —
+                                                # grantable only without path restriction
     ),
     # Guard 2 — operator-defined policy for every turn; classifier fully bypassed
     # (recommended for PRODUCTION; classifier-derived policy logs a warning there):
     default_policy=presets.standard(),
 )
 ```
+
+Path containment uses the same canonical resolution as lease enforcement (symlinks and `..` resolved against the real filesystem), so what the approver approves and what the lease enforces cannot disagree. Tools whose calls carry no extractable path argument (`bash` — a command string is not a file path) cannot be path-confined: a path-restricted `bash` lease would deny every call. Listing them in `unconfined_tools` is the explicit operator opt-in to grant them unrestricted (still bounded by `max_ops`, TTL and the flood guard) — omit the tool entirely if that is not acceptable.
 
 `console_escalation_callback` is the interactive alternative to the allowlist approver — it prompts a human on the terminal and denies when no TTY is attached.
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The heuristic classifier ships in core: rule-based, zero tokens, zero latency. P
 
 Policies derive minimum sufficient execution conditions — not static caps. A "rewrite repo" task gets broad context because the task requires it, not because limits were relaxed.
 
-Classification is advisory and misclassification stays cheap: session-level narrowing acts only on classifications the analyzer itself considers confident (single ambiguity source), an ambiguous first turn never becomes the irreversible session baseline, and the escalation ceiling — which capabilities may later be granted at all — is operator-defined, never preset/classifier-derived. Operator guards:
+Classification is advisory and misclassification stays cheap: session-level narrowing acts only on classifications the analyzer itself considers confident (single ambiguity source), an ambiguous classification never chooses authority (with no confident baseline the turn runs fail-closed under the safe fallback), and the escalation ceiling — which capabilities may later be granted at all — is operator-defined, never preset/classifier-derived. Operator guards:
 
 ```python
 from axor_core import GovernedSession, AllowlistEscalationApprover, presets

--- a/README.md
+++ b/README.md
@@ -225,9 +225,28 @@ Policy may be selected dynamically from task signals, or fixed explicitly by the
 | Rewrite repo | expansive | broad | light | allowed (d=3) |
 | Audit security | focused_readonly | minimal | aggressive | denied |
 
-The heuristic classifier ships in core: rule-based, zero tokens, zero latency. Plug in `axor-classifier-simple` or `axor-classifier-llm` for higher accuracy on ambiguous tasks.
+The heuristic classifier ships in core: rule-based, zero tokens, zero latency. Plug in `axor-classifier-simple` for higher accuracy on ambiguous tasks (English + Russian).
 
 Policies derive minimum sufficient execution conditions — not static caps. A "rewrite repo" task gets broad context because the task requires it, not because limits were relaxed.
+
+Classification is advisory and misclassification stays cheap: session-level narrowing acts only on confident classifications, and presets with a reduced tool surface allow per-tool recovery via `escalate_policy`. Two operator guards complete the picture:
+
+```python
+from axor_core import GovernedSession, AllowlistEscalationApprover, presets
+
+session = GovernedSession(
+    executor=..., capability_executor=...,
+    # Guard 1 — approve mid-run capability escalations (fail-closed without it):
+    escalation_callback=AllowlistEscalationApprover(
+        {"bash": 10, "write": 20}, allowed_path_prefixes=("/workspace",),
+    ),
+    # Guard 2 — operator-defined policy for every turn; classifier fully bypassed
+    # (recommended for PRODUCTION; classifier-derived policy logs a warning there):
+    default_policy=presets.standard(),
+)
+```
+
+`console_escalation_callback` is the interactive alternative to the allowlist approver — it prompts a human on the terminal and denies when no TTY is attached.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -229,22 +229,29 @@ The heuristic classifier ships in core: rule-based, zero tokens, zero latency. P
 
 Policies derive minimum sufficient execution conditions — not static caps. A "rewrite repo" task gets broad context because the task requires it, not because limits were relaxed.
 
-Classification is advisory and misclassification stays cheap: session-level narrowing acts only on confident classifications, and presets with a reduced tool surface allow per-tool recovery via `escalate_policy`. Two operator guards complete the picture:
+Classification is advisory and misclassification stays cheap: session-level narrowing acts only on classifications the analyzer itself considers confident (single ambiguity source), an ambiguous first turn never becomes the irreversible session baseline, and the escalation ceiling — which capabilities may later be granted at all — is operator-defined, never preset/classifier-derived. Operator guards:
 
 ```python
 from axor_core import GovernedSession, AllowlistEscalationApprover, presets
 
 session = GovernedSession(
     executor=..., capability_executor=...,
-    # Guard 1 — approve mid-run capability escalations (fail-closed without it):
+    # Escalation ceiling — which tools MAY later be granted (authority,
+    # operator-defined; classifier-selected presets carry none):
+    escalation_policy=EscalationPolicy(
+        allow_escalation=True, grantable_tools=("write", "bash"),
+        require_human=True,
+    ),
+    # Approval gate for those grants (fail-closed without it):
     escalation_callback=AllowlistEscalationApprover(
         {"bash": 10, "write": 20},
         allowed_path_prefixes=("/workspace",),  # confines path-bearing grants (write)
         unconfined_tools=("bash",),             # bash calls expose no checkable path —
                                                 # grantable only without path restriction
     ),
-    # Guard 2 — operator-defined policy for every turn; classifier fully bypassed
-    # (recommended for PRODUCTION; classifier-derived policy logs a warning there):
+    # Compatibility/security guard — operator-defined policy for every turn;
+    # classifier fully bypassed (also disables task-aware planning; the target
+    # model that separates the two is the AuthorityPolicy/ExecutionPlan split):
     default_policy=presets.standard(),
 )
 ```

--- a/axor_core/__init__.py
+++ b/axor_core/__init__.py
@@ -70,6 +70,8 @@ _LAZY = {
     # capability (Ring 1, light)
     "CapabilityExecutor": "axor_core.capability.executor",
     "ToolHandler": "axor_core.capability.executor",
+    "AllowlistEscalationApprover": "axor_core.capability.approvals",
+    "console_escalation_callback": "axor_core.capability.approvals",
     # governor (Ring 0 kernel only)
     "ToolCallGovernor": "axor_core.governor",
     "GovernanceDecision": "axor_core.governor",
@@ -127,6 +129,9 @@ if TYPE_CHECKING:  # static visibility for type checkers / IDEs (not loaded at r
     from axor_core.worker.session import GovernedSession
     from axor_core.budget import TokenCostRates
     from axor_core.capability.executor import CapabilityExecutor, ToolHandler
+    from axor_core.capability.approvals import (
+        AllowlistEscalationApprover, console_escalation_callback,
+    )
     from axor_core.governor import ToolCallGovernor, GovernanceDecision
     from axor_core.config import GovernanceConfig
     from axor_core.contracts.invokable import Invokable
@@ -165,6 +170,7 @@ __all__ = [
     "NullMemoryProvider",
     # capability
     "CapabilityExecutor", "ToolHandler",
+    "AllowlistEscalationApprover", "console_escalation_callback",
     # governor
     "ToolCallGovernor", "GovernanceDecision",
     "GovernanceConfig",

--- a/axor_core/capability/approvals.py
+++ b/axor_core/capability/approvals.py
@@ -1,0 +1,149 @@
+"""Ready-made escalation approval callbacks.
+
+An ``EscalationCallback`` is the human/operator half of capability-on-demand:
+presets whose tool surface is narrower than the full set allow escalation with
+``require_human=True``, so nothing is granted until a callback approves the
+(tool, paths, max_ops) request. Without a callback every such escalation is
+auto-denied (fail-closed).
+
+Signature (see :data:`axor_core.node.intent_loop.EscalationCallback`):
+
+    async (tool_use_id: str, tool: str, paths: list[str], max_ops: int) -> bool
+
+Two implementations ship in core:
+
+- :class:`AllowlistEscalationApprover` — deterministic operator policy:
+  approve requests that fall inside a statically configured allowlist.
+  No human in the loop at grant time; the operator's authority is the
+  configuration itself.
+- :func:`console_escalation_callback` — interactive human approval on a TTY;
+  denies when no interactive terminal is attached (fail-closed for headless
+  deployments).
+
+Both only *answer* the approval question. TTL, max-use, flood-guard and path
+enforcement of the resulting grant stay in :class:`EscalationManager` /
+``LeaseValidator`` — an over-permissive callback still cannot exceed the
+policy's ``escalation_policy`` bounds.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import PurePosixPath
+
+log = logging.getLogger("axor.capability.approvals")
+
+
+def _path_within(candidate: str, prefixes: tuple[str, ...]) -> bool:
+    """True if candidate resolves under one of the allowed prefixes.
+    Pure lexical containment on normalized segments — no filesystem access,
+    and ``..`` segments are rejected outright so a crafted path cannot
+    escape a prefix it lexically starts with."""
+    parts = PurePosixPath(candidate).parts
+    if ".." in parts:
+        return False
+    for prefix in prefixes:
+        if parts[: len(PurePosixPath(prefix).parts)] == PurePosixPath(prefix).parts:
+            return True
+    return False
+
+
+class AllowlistEscalationApprover:
+    """Operator-policy approver: approve escalations inside a static allowlist.
+
+    Args:
+        allowed_tools: tool name → maximum ``max_ops`` approvable per grant.
+            A requested ``max_ops`` above the cap denies the request (the
+            agent may retry with a smaller ask) rather than silently
+            shrinking the grant.
+        allowed_path_prefixes: when non-empty, every requested path must fall
+            under one of these prefixes, and a request with NO paths is
+            denied — an unconfined grant is broader than a confined
+            configuration allows (fail-closed).
+
+    Every decision is logged so grants remain attributable to the operator
+    configuration that produced them.
+    """
+
+    def __init__(
+        self,
+        allowed_tools: dict[str, int],
+        allowed_path_prefixes: tuple[str, ...] | list[str] = (),
+    ) -> None:
+        if not allowed_tools:
+            raise ValueError(
+                "AllowlistEscalationApprover with no allowed_tools would deny "
+                "everything — omit the callback instead"
+            )
+        bad = {t: cap for t, cap in allowed_tools.items() if cap <= 0}
+        if bad:
+            raise ValueError(f"allowed_tools caps must be positive: {bad}")
+        self._allowed_tools = dict(allowed_tools)
+        self._path_prefixes = tuple(allowed_path_prefixes)
+
+    async def __call__(
+        self, tool_use_id: str, tool: str, paths: list[str], max_ops: int
+    ) -> bool:
+        cap = self._allowed_tools.get(tool)
+        if cap is None:
+            log.info("escalation denied by allowlist: tool %r not allowed", tool)
+            return False
+        if max_ops > cap:
+            log.info(
+                "escalation denied by allowlist: tool %r max_ops %d > cap %d",
+                tool, max_ops, cap,
+            )
+            return False
+        if self._path_prefixes:
+            if not paths:
+                log.info(
+                    "escalation denied by allowlist: tool %r requested no path "
+                    "restriction but approver confines to %r",
+                    tool, self._path_prefixes,
+                )
+                return False
+            outside = [p for p in paths if not _path_within(p, self._path_prefixes)]
+            if outside:
+                log.info(
+                    "escalation denied by allowlist: tool %r paths %r outside %r",
+                    tool, outside, self._path_prefixes,
+                )
+                return False
+        log.info(
+            "escalation approved by allowlist: tool %r paths %r max_ops %d",
+            tool, paths, max_ops,
+        )
+        return True
+
+
+async def console_escalation_callback(
+    tool_use_id: str, tool: str, paths: list[str], max_ops: int
+) -> bool:
+    """Interactive human approval on the controlling terminal.
+
+    Denies when stdin is not a TTY — a headless deployment must configure an
+    operator-policy approver (or none) explicitly, never inherit an approval
+    prompt nobody can answer.
+    """
+    stdin = getattr(sys, "stdin", None)
+    try:
+        interactive = stdin is not None and stdin.isatty()
+    except (AttributeError, ValueError):
+        interactive = False
+    if not interactive:
+        log.info(
+            "escalation denied: console approval requested for tool %r but "
+            "stdin is not a TTY", tool,
+        )
+        return False
+
+    scope = f"paths {paths!r}" if paths else "no path restriction"
+    prompt = (
+        f"[axor] escalation request: grant tool {tool!r} ({scope}, "
+        f"max {max_ops} ops)? [y/N] "
+    )
+    # input() blocks; keep the event loop (and any concurrent governance
+    # work) responsive while the human decides.
+    answer = await asyncio.to_thread(input, prompt)
+    return answer.strip().lower() in ("y", "yes")

--- a/axor_core/capability/approvals.py
+++ b/axor_core/capability/approvals.py
@@ -23,30 +23,18 @@ Two implementations ship in core:
 Both only *answer* the approval question. TTL, max-use, flood-guard and path
 enforcement of the resulting grant stay in :class:`EscalationManager` /
 ``LeaseValidator`` — an over-permissive callback still cannot exceed the
-policy's ``escalation_policy`` bounds.
+policy's ``escalation_policy`` bounds. A callback that raises is treated as a
+denial by ``EscalationManager`` (fail-closed exception boundary).
 """
 from __future__ import annotations
 
 import asyncio
 import logging
 import sys
-from pathlib import PurePosixPath
+
+from axor_core.security.paths import paths_within
 
 log = logging.getLogger("axor.capability.approvals")
-
-
-def _path_within(candidate: str, prefixes: tuple[str, ...]) -> bool:
-    """True if candidate resolves under one of the allowed prefixes.
-    Pure lexical containment on normalized segments — no filesystem access,
-    and ``..`` segments are rejected outright so a crafted path cannot
-    escape a prefix it lexically starts with."""
-    parts = PurePosixPath(candidate).parts
-    if ".." in parts:
-        return False
-    for prefix in prefixes:
-        if parts[: len(PurePosixPath(prefix).parts)] == PurePosixPath(prefix).parts:
-            return True
-    return False
 
 
 class AllowlistEscalationApprover:
@@ -58,9 +46,22 @@ class AllowlistEscalationApprover:
             agent may retry with a smaller ask) rather than silently
             shrinking the grant.
         allowed_path_prefixes: when non-empty, every requested path must fall
-            under one of these prefixes, and a request with NO paths is
-            denied — an unconfined grant is broader than a confined
-            configuration allows (fail-closed).
+            under one of these roots, and a request with NO paths is denied —
+            an unconfined grant is broader than a confined configuration
+            allows (fail-closed). Containment uses the same canonical model
+            as lease enforcement (``axor_core.security.paths``): symlinks and
+            ``..`` are resolved against the real filesystem, so a link inside
+            a root cannot mint a new allowed root outside it.
+        unconfined_tools: tools whose calls carry no extractable path argument
+            (e.g. ``bash`` — its args are a command string, not a file path).
+            A path-restricted lease would deny every call of such a tool, so
+            path confinement CANNOT be meaningfully applied to it. Tools
+            listed here are grantable only WITHOUT a path restriction: their
+            requests must carry an empty ``paths`` (approved unrestricted,
+            bounded by max_ops/TTL), and a paths-carrying request is denied.
+            Listing a tool here is an explicit operator statement that its
+            grants are not path-confined — omit the tool entirely if that is
+            not acceptable.
 
     Every decision is logged so grants remain attributable to the operator
     configuration that produced them.
@@ -70,6 +71,7 @@ class AllowlistEscalationApprover:
         self,
         allowed_tools: dict[str, int],
         allowed_path_prefixes: tuple[str, ...] | list[str] = (),
+        unconfined_tools: tuple[str, ...] | list[str] = (),
     ) -> None:
         if not allowed_tools:
             raise ValueError(
@@ -79,8 +81,14 @@ class AllowlistEscalationApprover:
         bad = {t: cap for t, cap in allowed_tools.items() if cap <= 0}
         if bad:
             raise ValueError(f"allowed_tools caps must be positive: {bad}")
+        unknown = set(unconfined_tools) - set(allowed_tools)
+        if unknown:
+            raise ValueError(
+                f"unconfined_tools not present in allowed_tools: {sorted(unknown)}"
+            )
         self._allowed_tools = dict(allowed_tools)
         self._path_prefixes = tuple(allowed_path_prefixes)
+        self._unconfined_tools = frozenset(unconfined_tools)
 
     async def __call__(
         self, tool_use_id: str, tool: str, paths: list[str], max_ops: int
@@ -95,7 +103,19 @@ class AllowlistEscalationApprover:
                 tool, max_ops, cap,
             )
             return False
-        if self._path_prefixes:
+        if tool in self._unconfined_tools:
+            # A path-restricted grant for this tool would be unusable (its
+            # calls expose no path to check), so only a path-free request is
+            # approvable — deny a paths-carrying one and let the agent retry
+            # without paths.
+            if paths:
+                log.info(
+                    "escalation denied by allowlist: tool %r is unconfined-only "
+                    "but requested paths %r (retry without paths)",
+                    tool, paths,
+                )
+                return False
+        elif self._path_prefixes:
             if not paths:
                 log.info(
                     "escalation denied by allowlist: tool %r requested no path "
@@ -103,11 +123,14 @@ class AllowlistEscalationApprover:
                     tool, self._path_prefixes,
                 )
                 return False
-            outside = [p for p in paths if not _path_within(p, self._path_prefixes)]
-            if outside:
+            # Canonical containment (symlink/.. resolving) — the SAME model
+            # LeaseValidator enforces with, so approval and enforcement cannot
+            # disagree about what "inside the workspace" means.
+            if not paths_within(paths, self._path_prefixes):
                 log.info(
-                    "escalation denied by allowlist: tool %r paths %r outside %r",
-                    tool, outside, self._path_prefixes,
+                    "escalation denied by allowlist: tool %r paths %r do not "
+                    "resolve within %r",
+                    tool, paths, self._path_prefixes,
                 )
                 return False
         log.info(
@@ -124,7 +147,8 @@ async def console_escalation_callback(
 
     Denies when stdin is not a TTY — a headless deployment must configure an
     operator-policy approver (or none) explicitly, never inherit an approval
-    prompt nobody can answer.
+    prompt nobody can answer. A terminal error mid-prompt (EOF, closed
+    stream) also denies.
     """
     stdin = getattr(sys, "stdin", None)
     try:
@@ -145,5 +169,9 @@ async def console_escalation_callback(
     )
     # input() blocks; keep the event loop (and any concurrent governance
     # work) responsive while the human decides.
-    answer = await asyncio.to_thread(input, prompt)
+    try:
+        answer = await asyncio.to_thread(input, prompt)
+    except (EOFError, OSError, ValueError):
+        log.info("escalation denied: console prompt failed for tool %r", tool)
+        return False
     return answer.strip().lower() in ("y", "yes")

--- a/axor_core/node/escalation.py
+++ b/axor_core/node/escalation.py
@@ -16,8 +16,11 @@ Pure move of the loop's logic — same order, same decisions, same trace events.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+_log = logging.getLogger("axor.escalation")
 
 from axor_core.capability.flood import EscalationFloodGuard
 from axor_core.capability.lease_validator import (
@@ -216,9 +219,19 @@ class EscalationManager:
                 return _deny(
                     "escalation requires human approval but no callback is configured"
                 )
-            approved = await self._escalation_callback(
-                tool_use_id, tool, paths, max_ops
-            )
+            # Fail-closed exception boundary: a crashing approver (terminal
+            # EOF, broken operator callback) is a denial with a proper trace
+            # event, never an exception escaping governed execution.
+            try:
+                approved = await self._escalation_callback(
+                    tool_use_id, tool, paths, max_ops
+                )
+            except Exception:
+                _log.exception(
+                    "escalation approval callback raised for tool %r — denying",
+                    tool,
+                )
+                return _deny("escalation approval callback failed")
             auto_approved = False
             if not approved:
                 return _deny("human denied escalation request")

--- a/axor_core/policy/analyzer.py
+++ b/axor_core/policy/analyzer.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import logging
+
 from axor_core.contracts.policy import SignalClassifier, TaskSignal
 from axor_core.contracts.trace import (
     SignalChosenEvent,
     TraceEventKind,
 )
 from axor_core.policy.heuristic import HeuristicClassifier
+
+_log = logging.getLogger("axor.policy.analyzer")
 
 # If confidence is below this threshold and an external classifier
 # is available — escalate. Otherwise use heuristic result as-is.
@@ -142,20 +146,40 @@ class TaskAnalyzer:
         """
         signal, confidence, scores = await self._heuristic.classify_with_scores(raw_input)
         classifier_used = "heuristic"
+        external_domain = ""
 
         if confidence < self._threshold and self._external is not None:
-            ext_signal, ext_conf, ext_scores = await self._external.classify_with_scores(raw_input)
-            if ext_conf > confidence:
-                signal = ext_signal
-                confidence = ext_conf
-                classifier_used = type(self._external).__name__
-                # external scores replace heuristic scores only if provided;
-                # empty dict means external did not expose a distribution
-                if ext_scores:
-                    scores = ext_scores
+            # Fail-closed (classifier-threat-model.md): a broken external
+            # classifier degrades to the heuristic result — it never crashes
+            # governed execution.
+            try:
+                ext_signal, ext_conf, ext_scores = await self._external.classify_with_scores(raw_input)
+            except Exception:
+                _log.warning(
+                    "external classifier %s raised; falling back to heuristic result",
+                    type(self._external).__name__,
+                    exc_info=True,
+                )
+            else:
+                if ext_conf > confidence:
+                    signal = ext_signal
+                    confidence = ext_conf
+                    classifier_used = type(self._external).__name__
+                    external_domain = ext_signal.domain
+                    # external scores replace heuristic scores only if provided;
+                    # empty dict means external did not expose a distribution
+                    if ext_scores:
+                        scores = ext_scores
 
-        # domain detection — agent domain takes priority over task-level
-        domain = _detect_domain(raw_input, self._agent_domain)
+        # domain resolution priority: agent domain (operator-declared) →
+        # external classifier's domain head (when it won the escalation and
+        # produced a non-default domain) → keyword detection fallback.
+        if self._agent_domain != "general":
+            domain = self._agent_domain
+        elif external_domain and external_domain != "general":
+            domain = external_domain
+        else:
+            domain = _detect_domain(raw_input, self._agent_domain)
         # domain distribution always comes from the text heuristic; agent-domain
         # assignment is a policy override, not a probabilistic statement.
         scores = {**scores, **_marginal_domain_scores(raw_input)}

--- a/axor_core/policy/analyzer.py
+++ b/axor_core/policy/analyzer.py
@@ -139,6 +139,15 @@ class TaskAnalyzer:
         self._threshold    = escalation_threshold
         self._agent_domain = agent_domain   # from AgentDefinition.domain
 
+    @property
+    def ambiguity_threshold(self) -> float:
+        """The single source of the ambiguity decision: classifications below
+        this confidence are ambiguous. Consumers (e.g. the session's adaptive
+        narrowing) must read this property instead of hard-coding a number —
+        the analyzer's configured threshold and the session's interpretation
+        of confidence must never diverge."""
+        return self._threshold
+
     async def analyze(self, raw_input: str) -> tuple[TaskSignal, SignalChosenEvent]:
         """
         Classify raw input into a TaskSignal with domain detection.

--- a/axor_core/policy/selector.py
+++ b/axor_core/policy/selector.py
@@ -5,12 +5,27 @@ from axor_core.contracts.policy import (
     TaskComplexity,
     TaskNature,
     ExecutionPolicy,
+    EscalationPolicy,
     ContextMode,
     CompressionMode,
     ExportMode,
     ChildMode,
     ToolPolicy,
 )
+
+
+def _on_demand_escalation(*grantable: str) -> EscalationPolicy:
+    """Capability-on-demand escalation for a preset whose tool surface is
+    narrower than the full set. Classification is advisory and can be wrong;
+    when it under-provisions, the agent recovers per-tool via escalate_policy
+    instead of failing the task. require_human=True keeps this fail-closed:
+    without an operator-wired escalation callback nothing is ever granted,
+    and PolicyComposer's overlay intersection can only narrow it further."""
+    return EscalationPolicy(
+        allow_escalation=True,
+        grantable_tools=tuple(grantable),
+        require_human=True,
+    )
 
 
 class PolicySelector:
@@ -56,6 +71,7 @@ class PolicySelector:
                     ),
                     export_mode=ExportMode.SUMMARY,
                     child_context_fraction=0.0,
+                    escalation_policy=_on_demand_escalation("write", "bash"),
                 )
 
             case (TaskComplexity.FOCUSED, TaskNature.GENERATIVE):
@@ -75,6 +91,7 @@ class PolicySelector:
                     ),
                     export_mode=ExportMode.SUMMARY,
                     child_context_fraction=0.0,
+                    escalation_policy=_on_demand_escalation("bash"),
                 )
 
             case (TaskComplexity.FOCUSED, TaskNature.MUTATIVE):
@@ -113,6 +130,7 @@ class PolicySelector:
                     ),
                     export_mode=ExportMode.FILTERED,
                     child_context_fraction=0.0,
+                    escalation_policy=_on_demand_escalation("write", "bash"),
                 )
 
             case (TaskComplexity.MODERATE, TaskNature.GENERATIVE):
@@ -195,4 +213,5 @@ class PolicySelector:
             ),
             export_mode=ExportMode.SUMMARY,
             child_context_fraction=0.0,
+            escalation_policy=_on_demand_escalation("search", "write", "bash"),
         )

--- a/axor_core/policy/selector.py
+++ b/axor_core/policy/selector.py
@@ -5,7 +5,6 @@ from axor_core.contracts.policy import (
     TaskComplexity,
     TaskNature,
     ExecutionPolicy,
-    EscalationPolicy,
     ContextMode,
     CompressionMode,
     ExportMode,
@@ -13,19 +12,12 @@ from axor_core.contracts.policy import (
     ToolPolicy,
 )
 
-
-def _on_demand_escalation(*grantable: str) -> EscalationPolicy:
-    """Capability-on-demand escalation for a preset whose tool surface is
-    narrower than the full set. Classification is advisory and can be wrong;
-    when it under-provisions, the agent recovers per-tool via escalate_policy
-    instead of failing the task. require_human=True keeps this fail-closed:
-    without an operator-wired escalation callback nothing is ever granted,
-    and PolicyComposer's overlay intersection can only narrow it further."""
-    return EscalationPolicy(
-        allow_escalation=True,
-        grantable_tools=tuple(grantable),
-        require_human=True,
-    )
+# NOTE: classifier-selected presets deliberately carry NO EscalationPolicy.
+# Which capabilities may later be granted (the escalation ceiling) is an
+# AUTHORITY decision — it must come from the operator
+# (GovernedSession(escalation_policy=...) or an explicit policy), never from
+# an interpretation of the task text. A preset-carried grantable_tools list
+# would make the classifier a co-author of authority composition.
 
 
 class PolicySelector:
@@ -71,7 +63,6 @@ class PolicySelector:
                     ),
                     export_mode=ExportMode.SUMMARY,
                     child_context_fraction=0.0,
-                    escalation_policy=_on_demand_escalation("write", "bash"),
                 )
 
             case (TaskComplexity.FOCUSED, TaskNature.GENERATIVE):
@@ -91,7 +82,6 @@ class PolicySelector:
                     ),
                     export_mode=ExportMode.SUMMARY,
                     child_context_fraction=0.0,
-                    escalation_policy=_on_demand_escalation("bash"),
                 )
 
             case (TaskComplexity.FOCUSED, TaskNature.MUTATIVE):
@@ -130,7 +120,6 @@ class PolicySelector:
                     ),
                     export_mode=ExportMode.FILTERED,
                     child_context_fraction=0.0,
-                    escalation_policy=_on_demand_escalation("write", "bash"),
                 )
 
             case (TaskComplexity.MODERATE, TaskNature.GENERATIVE):
@@ -213,5 +202,4 @@ class PolicySelector:
             ),
             export_mode=ExportMode.SUMMARY,
             child_context_fraction=0.0,
-            escalation_policy=_on_demand_escalation("search", "write", "bash"),
         )

--- a/axor_core/worker/session.py
+++ b/axor_core/worker/session.py
@@ -87,7 +87,9 @@ class GovernedSession:
             mode=ExecutionMode.PRODUCTION,
             default_policy=presets.standard(),
             escalation_callback=AllowlistEscalationApprover(
-                {"bash": 10}, allowed_path_prefixes=("/workspace",),
+                {"write": 20, "bash": 10},
+                allowed_path_prefixes=("/workspace",),  # confines write grants
+                unconfined_tools=("bash",),  # bash exposes no checkable path
             ),
         )
 

--- a/axor_core/worker/session.py
+++ b/axor_core/worker/session.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from axor_core.contracts.agent import AgentDefinition
     from axor_core.contracts.memory import MemoryProvider
     from axor_core.contracts.session import SessionSink
+    from axor_core.node.intent_loop import EscalationCallback
 from axor_core.contracts.cancel import make_token, CancelReason
 from axor_core.contracts.session import SessionAuditRecord, ToolInvocationRecord
 from axor_core.contracts.context import RawExecutionState, LineageSummary
@@ -73,7 +74,21 @@ class GovernedSession:
         session = GovernedSession(
             executor=ClaudeCodeExecutor(),
             capability_executor=cap_executor,
-            classifier=LocalTrainedClassifier(),
+            classifier=TaskSignalClassifier(),   # axor-classifier-simple
+        )
+
+    Recommended PRODUCTION posture — operator-defined policy (classifier
+    bypassed) plus an escalation approver so a too-narrow policy recovers
+    per-tool instead of failing the task:
+
+        session = GovernedSession(
+            executor=ClaudeCodeExecutor(),
+            capability_executor=cap_executor,
+            mode=ExecutionMode.PRODUCTION,
+            default_policy=presets.standard(),
+            escalation_callback=AllowlistEscalationApprover(
+                {"bash": 10}, allowed_path_prefixes=("/workspace",),
+            ),
         )
 
     With soft token limit:
@@ -98,6 +113,8 @@ class GovernedSession:
         executor: Invokable,
         capability_executor: CapabilityExecutor,
         classifier: SignalClassifier | None = None,
+        escalation_callback: "EscalationCallback | None" = None,
+        default_policy: ExecutionPolicy | None = None,
         behavioral_drift_observer: BehavioralDriftObserver | None = None,
         extension_loaders: list[ExtensionLoader] | None = None,
         trace_config: TraceConfig | None = None,
@@ -238,6 +255,17 @@ class GovernedSession:
 
         self._deny_on_ambiguity: bool = (mode == ExecutionMode.STRICT)
         self._strict_escalation: bool = (mode == ExecutionMode.STRICT)
+
+        # Human/operator escalation gate — threaded into every node's IntentLoop
+        # (children inherit it at spawn). None → require_human escalations are
+        # auto-denied (fail-closed). See axor_core.capability.approvals for
+        # ready-made callbacks.
+        self._escalation_callback = escalation_callback
+        # Session-wide explicit policy: used whenever run() gets no per-call
+        # policy=. With it set the task classifier is bypassed entirely —
+        # the recommended posture for PRODUCTION deployments.
+        self._default_policy = default_policy
+        self._classifier_policy_warned = False
 
         # Process-isolation gate. In PRODUCTION/STRICT an untrusted
         # agent should execute tools out-of-process (DaemonCapabilityClient);
@@ -494,6 +522,21 @@ class GovernedSession:
         cancel_token = make_token()
         self._active_token = cancel_token
 
+        # Explicit policy resolution: per-call policy= wins over the session's
+        # default_policy. With either set, the classifier is bypassed entirely.
+        if policy is None:
+            policy = self._default_policy
+            if policy is None and self._mode == ExecutionMode.PRODUCTION \
+                    and not self._classifier_policy_warned:
+                _log.warning(
+                    "session=%s PRODUCTION mode is deriving policy from task "
+                    "classification (advisory, content-based). Recommended: pass "
+                    "an explicit policy= per call or default_policy= at "
+                    "construction to make policy operator-defined.",
+                    self._session_id,
+                )
+                self._classifier_policy_warned = True
+
         # Adaptive policy: re-classify each turn; capability surface can only
         # narrow automatically — broadening requires an explicit operator override.
         # Narrowing is confidence-gated: a low-confidence re-classification must
@@ -742,6 +785,7 @@ class GovernedSession:
             analyzer=self._analyzer,
             selector=self._selector,
             composer=self._composer,
+            escalation_callback=self._escalation_callback,
             context_manager=context_manager,
             budget_engine=self._budget_engine,
             trace_collector=self._collector,

--- a/axor_core/worker/session.py
+++ b/axor_core/worker/session.py
@@ -46,6 +46,13 @@ from axor_core.tokens import estimate_tokens
 
 _log = logging.getLogger("axor.session")
 
+# Adaptive narrowing is applied only when the classifier is at least this
+# confident. Narrowing is monotonic (never undone automatically), so acting on
+# a low-confidence guess would make one misread turn permanently strip
+# capability from the whole session. Matches the analyzer's escalation
+# threshold: below it the classification is by definition ambiguous.
+_NARROW_CONFIDENCE_THRESHOLD = 0.75
+
 
 class GovernedSession:
     """
@@ -489,13 +496,21 @@ class GovernedSession:
 
         # Adaptive policy: re-classify each turn; capability surface can only
         # narrow automatically — broadening requires an explicit operator override.
+        # Narrowing is confidence-gated: a low-confidence re-classification must
+        # not permanently strip capability from the whole session (classification
+        # is advisory; its errors have to stay cheap). Recovery from an
+        # over-narrow start is per-tool via escalate_policy, not re-broadening.
         effective_policy = policy
         if policy is None:
-            signal, _ = await self._analyzer.analyze(task)
+            signal, signal_event = await self._analyzer.analyze(task)
             new_policy = self._selector.select(signal)
+            # Custom analyzers may return no event; treat absent confidence as
+            # authoritative (legacy behaviour) — the stock TaskAnalyzer always
+            # reports one.
+            confidence = getattr(signal_event, "confidence", None)
             if self._active_policy is None:
                 self._active_policy = new_policy
-            else:
+            elif confidence is None or confidence >= _NARROW_CONFIDENCE_THRESHOLD:
                 narrowed = self._composer.apply_parent_restrictions(
                     new_policy, self._active_policy
                 )
@@ -507,6 +522,15 @@ class GovernedSession:
                         narrowed.name,
                     )
                 self._active_policy = narrowed
+            else:
+                _log.info(
+                    "session=%s adaptive narrowing skipped: classification "
+                    "confidence %.2f < %.2f (policy stays %s)",
+                    self._session_id,
+                    confidence,
+                    _NARROW_CONFIDENCE_THRESHOLD,
+                    self._active_policy.name,
+                )
             effective_policy = self._active_policy
 
         node = self._make_node(self._context_manager)

--- a/axor_core/worker/session.py
+++ b/axor_core/worker/session.py
@@ -455,6 +455,25 @@ class GovernedSession:
             **kwargs,
         )
 
+    def _apply_operator_escalation(self, policy: ExecutionPolicy) -> ExecutionPolicy:
+        """Stamp the operator-defined escalation ceiling onto a policy the
+        operator did NOT write per-call (session default_policy or a
+        classifier-selected preset). A per-call policy= keeps its own
+        escalation config — explicit per-call config is the top of the
+        precedence chain:
+
+            per-call policy escalation
+              > session escalation_policy (applied to default_policy and
+                classifier-selected policies)
+              > the policy's own (default: disabled)
+        """
+        if self._operator_escalation is None:
+            return policy
+        import dataclasses
+        return dataclasses.replace(
+            policy, escalation_policy=self._operator_escalation
+        )
+
     async def run(
         self,
         task: str,
@@ -540,18 +559,22 @@ class GovernedSession:
 
         # Explicit policy resolution: per-call policy= wins over the session's
         # default_policy. With either set, the classifier is bypassed entirely.
-        if policy is None:
-            policy = self._default_policy
-            if policy is None and self._mode == ExecutionMode.PRODUCTION \
-                    and not self._classifier_policy_warned:
-                _log.warning(
-                    "session=%s PRODUCTION mode is deriving policy from task "
-                    "classification (advisory, content-based). Recommended: pass "
-                    "an explicit policy= per call or default_policy= at "
-                    "construction to make policy operator-defined.",
-                    self._session_id,
-                )
-                self._classifier_policy_warned = True
+        # The operator escalation ceiling applies to the session default too —
+        # the README production configuration (default_policy + escalation_policy
+        # + approver) works as written; only a per-call policy keeps its own
+        # escalation config (see _apply_operator_escalation).
+        if policy is None and self._default_policy is not None:
+            policy = self._apply_operator_escalation(self._default_policy)
+        if policy is None and self._mode == ExecutionMode.PRODUCTION \
+                and not self._classifier_policy_warned:
+            _log.warning(
+                "session=%s PRODUCTION mode is deriving policy from task "
+                "classification (advisory, content-based). Recommended: pass "
+                "an explicit policy= per call or default_policy= at "
+                "construction to make policy operator-defined.",
+                self._session_id,
+            )
+            self._classifier_policy_warned = True
 
         # Adaptive policy: re-classify each turn; capability surface can only
         # narrow automatically — broadening requires an explicit operator override.
@@ -563,13 +586,9 @@ class GovernedSession:
         if policy is None:
             signal, signal_event = await self._analyzer.analyze(task)
             new_policy = self._selector.select(signal)
-            if self._operator_escalation is not None:
-                # Escalation ceiling is operator authority, not classifier
-                # output — stamp it onto whatever preset was selected.
-                import dataclasses as _dc
-                new_policy = _dc.replace(
-                    new_policy, escalation_policy=self._operator_escalation
-                )
+            # Escalation ceiling is operator authority, not classifier
+            # output — stamp it onto whatever preset was selected.
+            new_policy = self._apply_operator_escalation(new_policy)
             # Custom analyzers may return no event; treat absent confidence as
             # authoritative (legacy behaviour) — the stock TaskAnalyzer always
             # reports one. The ambiguity decision itself belongs to the
@@ -589,13 +608,25 @@ class GovernedSession:
                     self._active_policy = new_policy
                     effective_policy = self._active_policy
                 else:
+                    # An ambiguous classification must not choose authority —
+                    # not even for one turn: an ambiguous "expansive" would
+                    # hand out write/bash/spawn right now, and a completed
+                    # effect cannot be un-happened by refusing to set the
+                    # baseline afterwards. Run fail-closed instead; the
+                    # operator escalation ceiling still applies, so recovery
+                    # is per-tool via escalate_policy, not via trusting the
+                    # guess.
+                    fallback = self._apply_operator_escalation(
+                        self._selector.safe_fallback()
+                    )
                     _log.info(
                         "session=%s ambiguous first classification "
-                        "(confidence %.2f < %.2f): policy %s applies to this "
-                        "turn only, adaptive baseline not set",
-                        self._session_id, confidence, threshold, new_policy.name,
+                        "(confidence %.2f < %.2f): candidate %s NOT applied; "
+                        "running under fail-closed '%s', baseline not set",
+                        self._session_id, confidence, threshold,
+                        new_policy.name, fallback.name,
                     )
-                    effective_policy = new_policy
+                    effective_policy = fallback
             elif confident:
                 narrowed = self._composer.apply_parent_restrictions(
                     new_policy, self._active_policy

--- a/axor_core/worker/session.py
+++ b/axor_core/worker/session.py
@@ -19,7 +19,11 @@ from axor_core.contracts.drift import BehavioralDriftObserver
 from axor_core.contracts.observation import ContextTap
 from axor_core.contracts.invokable import Invokable
 from axor_core.contracts.mode import ExecutionMode
-from axor_core.contracts.policy import ExecutionPolicy, SignalClassifier
+from axor_core.contracts.policy import (
+    EscalationPolicy,
+    ExecutionPolicy,
+    SignalClassifier,
+)
 from axor_core.contracts.result import ExecutionResult
 from axor_core.contracts.trace import TraceConfig
 from axor_core.capability.executor import CapabilityExecutor
@@ -47,12 +51,11 @@ from axor_core.tokens import estimate_tokens
 
 _log = logging.getLogger("axor.session")
 
-# Adaptive narrowing is applied only when the classifier is at least this
-# confident. Narrowing is monotonic (never undone automatically), so acting on
-# a low-confidence guess would make one misread turn permanently strip
-# capability from the whole session. Matches the analyzer's escalation
-# threshold: below it the classification is by definition ambiguous.
-_NARROW_CONFIDENCE_THRESHOLD = 0.75
+# Fallback ambiguity threshold, used ONLY when the analyzer does not expose
+# one (custom analyzers). The stock TaskAnalyzer owns the ambiguity decision
+# via its ambiguity_threshold property — the session never re-interprets
+# confidence with its own number, so the two cannot diverge.
+_FALLBACK_AMBIGUITY_THRESHOLD = 0.75
 
 
 class GovernedSession:
@@ -77,15 +80,21 @@ class GovernedSession:
             classifier=TaskSignalClassifier(),   # axor-classifier-simple
         )
 
-    Recommended PRODUCTION posture — operator-defined policy (classifier
-    bypassed) plus an escalation approver so a too-narrow policy recovers
-    per-tool instead of failing the task:
+    PRODUCTION compatibility/security guard — operator-defined policy
+    (classifier fully bypassed, which also disables task-aware planning;
+    the target model separating authority from planning is the
+    AuthorityPolicy/ExecutionPlan split) plus an operator escalation
+    ceiling and approver so a too-narrow policy recovers per-tool:
 
         session = GovernedSession(
             executor=ClaudeCodeExecutor(),
             capability_executor=cap_executor,
             mode=ExecutionMode.PRODUCTION,
             default_policy=presets.standard(),
+            escalation_policy=EscalationPolicy(
+                allow_escalation=True, grantable_tools=("write", "bash"),
+                require_human=True,
+            ),
             escalation_callback=AllowlistEscalationApprover(
                 {"write": 20, "bash": 10},
                 allowed_path_prefixes=("/workspace",),  # confines write grants
@@ -116,6 +125,7 @@ class GovernedSession:
         capability_executor: CapabilityExecutor,
         classifier: SignalClassifier | None = None,
         escalation_callback: "EscalationCallback | None" = None,
+        escalation_policy: "EscalationPolicy | None" = None,
         default_policy: ExecutionPolicy | None = None,
         behavioral_drift_observer: BehavioralDriftObserver | None = None,
         extension_loaders: list[ExtensionLoader] | None = None,
@@ -263,6 +273,10 @@ class GovernedSession:
         # auto-denied (fail-closed). See axor_core.capability.approvals for
         # ready-made callbacks.
         self._escalation_callback = escalation_callback
+        # Operator-defined escalation ceiling (authority). Applied to every
+        # classifier-selected policy: which capabilities may later be granted
+        # is never derived from task text — presets carry no escalation.
+        self._operator_escalation = escalation_policy
         # Session-wide explicit policy: used whenever run() gets no per-call
         # policy=. With it set the task classifier is bypassed entirely —
         # the recommended posture for PRODUCTION deployments.
@@ -549,13 +563,40 @@ class GovernedSession:
         if policy is None:
             signal, signal_event = await self._analyzer.analyze(task)
             new_policy = self._selector.select(signal)
+            if self._operator_escalation is not None:
+                # Escalation ceiling is operator authority, not classifier
+                # output — stamp it onto whatever preset was selected.
+                import dataclasses as _dc
+                new_policy = _dc.replace(
+                    new_policy, escalation_policy=self._operator_escalation
+                )
             # Custom analyzers may return no event; treat absent confidence as
             # authoritative (legacy behaviour) — the stock TaskAnalyzer always
-            # reports one.
+            # reports one. The ambiguity decision itself belongs to the
+            # analyzer (single source), never re-derived here.
             confidence = getattr(signal_event, "confidence", None)
+            threshold = getattr(
+                self._analyzer, "ambiguity_threshold", _FALLBACK_AMBIGUITY_THRESHOLD
+            )
+            confident = confidence is None or confidence >= threshold
             if self._active_policy is None:
-                self._active_policy = new_policy
-            elif confidence is None or confidence >= _NARROW_CONFIDENCE_THRESHOLD:
+                # An AMBIGUOUS classification is applied to this turn only —
+                # it must not become the session's irreversible adaptive
+                # baseline. The baseline is set by the first confident
+                # classification (which may be broader than an earlier
+                # ambiguous guess: nothing was locked by it).
+                if confident:
+                    self._active_policy = new_policy
+                    effective_policy = self._active_policy
+                else:
+                    _log.info(
+                        "session=%s ambiguous first classification "
+                        "(confidence %.2f < %.2f): policy %s applies to this "
+                        "turn only, adaptive baseline not set",
+                        self._session_id, confidence, threshold, new_policy.name,
+                    )
+                    effective_policy = new_policy
+            elif confident:
                 narrowed = self._composer.apply_parent_restrictions(
                     new_policy, self._active_policy
                 )
@@ -567,16 +608,17 @@ class GovernedSession:
                         narrowed.name,
                     )
                 self._active_policy = narrowed
+                effective_policy = self._active_policy
             else:
                 _log.info(
                     "session=%s adaptive narrowing skipped: classification "
                     "confidence %.2f < %.2f (policy stays %s)",
                     self._session_id,
                     confidence,
-                    _NARROW_CONFIDENCE_THRESHOLD,
+                    threshold,
                     self._active_policy.name,
                 )
-            effective_policy = self._active_policy
+                effective_policy = self._active_policy
 
         node = self._make_node(self._context_manager)
         result = await node.run(

--- a/docs/security/classifier-threat-model.md
+++ b/docs/security/classifier-threat-model.md
@@ -113,31 +113,28 @@ coefficient data.
 Classification is advisory and will sometimes be wrong. Two mechanisms keep a
 wrong guess cheap instead of trying to make the classifier perfect:
 
-- **Confidence-gated narrowing.** Session-level adaptive narrowing is
-  monotonic (capability never re-broadens automatically), so it acts only on
-  classifications at or above the confidence threshold. A single
-  low-confidence misread turn cannot permanently strip capability from the
-  whole session. Note the exact scope: the gate applies to *subsequent
-  narrowing only*. The FIRST turn's policy is still classifier-selected
-  regardless of confidence (a session needs a starting policy), so "low
-  confidence" does not mean "no policy effect" — a wrong ambiguous start is
-  recovered per-tool via escalation or overridden by an explicit
-  `policy=` / `default_policy=`, never by automatic re-broadening.
-- **Capability-on-demand.** Presets whose tool surface is narrower than the
-  full set carry an `EscalationPolicy` whose `grantable_tools` covers exactly
-  what the preset lacks (e.g. `focused_readonly` → `write`, `bash`). An
-  under-provisioned task recovers per-tool via `escalate_policy` behind the
-  flood guard and `require_human=True` — nothing is granted unless the
-  operator wires an approval callback, and the overlay/parent intersection
-  can only narrow the grantable set further.
+- **Confidence-gated narrowing (single ambiguity source).** Session-level
+  adaptive narrowing is monotonic, so it acts only on classifications the
+  ANALYZER considers confident — the threshold is read from
+  `TaskAnalyzer.ambiguity_threshold`, never re-derived by the session, so
+  the analyzer's configuration and the session's interpretation cannot
+  diverge. An ambiguous FIRST classification applies to that turn only and
+  does not become the irreversible adaptive baseline; the baseline is set
+  by the first confident classification.
+- **Operator-defined escalation ceiling.** Classifier-selected presets
+  carry NO escalation policy: which capabilities may later be granted is an
+  authority decision. The operator sets the ceiling via
+  `GovernedSession(escalation_policy=...)` (stamped onto every
+  classifier-selected policy) or an explicit policy; `escalate_policy`
+  grants then run behind the approval callback, flood guard and TTL leases.
 
-### Adversarial Task Text
-
-Task text is attacker-controlled when the user is untrusted or when the
-session is processing external content.  In STRICT mode, no classification
-happens from task text, so this attack surface is eliminated.
-
----
+Note on scope: these mechanisms contain the cost of the LEGACY model, in
+which classification still selects the initial `ExecutionPolicy` (tools
+included). The structural fix — classification removed from the authority
+path entirely (`AuthorityPolicy` operator-defined, `ExecutionPlan`
+classifier-shaped) — is the authority/plan split series; `default_policy=`
+and the containment above are the compatibility-window guards, not the
+target architecture.
 
 ## What the Classifier Does Not Do
 

--- a/docs/security/classifier-threat-model.md
+++ b/docs/security/classifier-threat-model.md
@@ -118,9 +118,11 @@ wrong guess cheap instead of trying to make the classifier perfect:
   ANALYZER considers confident — the threshold is read from
   `TaskAnalyzer.ambiguity_threshold`, never re-derived by the session, so
   the analyzer's configuration and the session's interpretation cannot
-  diverge. An ambiguous FIRST classification applies to that turn only and
-  does not become the irreversible adaptive baseline; the baseline is set
-  by the first confident classification.
+  diverge. An ambiguous classification never chooses authority — not
+  even for one turn: with no confident baseline yet, the turn runs
+  fail-closed under `safe_fallback` (read-only, no spawn; the operator
+  escalation ceiling still applies for per-tool recovery). The adaptive
+  baseline is set only by the first confident classification.
 - **Operator-defined escalation ceiling.** Classifier-selected presets
   carry NO escalation policy: which capabilities may later be granted is an
   authority decision. The operator sets the ceiling via

--- a/docs/security/classifier-threat-model.md
+++ b/docs/security/classifier-threat-model.md
@@ -117,7 +117,12 @@ wrong guess cheap instead of trying to make the classifier perfect:
   monotonic (capability never re-broadens automatically), so it acts only on
   classifications at or above the confidence threshold. A single
   low-confidence misread turn cannot permanently strip capability from the
-  whole session.
+  whole session. Note the exact scope: the gate applies to *subsequent
+  narrowing only*. The FIRST turn's policy is still classifier-selected
+  regardless of confidence (a session needs a starting policy), so "low
+  confidence" does not mean "no policy effect" — a wrong ambiguous start is
+  recovered per-tool via escalation or overridden by an explicit
+  `policy=` / `default_policy=`, never by automatic re-broadening.
 - **Capability-on-demand.** Presets whose tool surface is narrower than the
   full set carry an `EscalationPolicy` whose `grantable_tools` covers exactly
   what the preset lacks (e.g. `focused_readonly` → `write`, `bash`). An

--- a/docs/security/classifier-threat-model.md
+++ b/docs/security/classifier-threat-model.md
@@ -102,9 +102,29 @@ Mitigations:
 
 ### Classifier Failure
 
-If the classifier raises an exception, `TaskAnalyzer` falls back to the
-DEFAULT policy preset.  The DEFAULT preset is the most restrictive preset —
-fail-closed.
+If the external (ML) classifier raises an exception, `TaskAnalyzer` catches
+it, logs a warning, and keeps the heuristic result — a broken or unreachable
+external classifier can never crash governed execution. The heuristic itself
+never escalates and degrades to "focused / no signal" on malformed
+coefficient data.
+
+### Misclassification Cost Containment
+
+Classification is advisory and will sometimes be wrong. Two mechanisms keep a
+wrong guess cheap instead of trying to make the classifier perfect:
+
+- **Confidence-gated narrowing.** Session-level adaptive narrowing is
+  monotonic (capability never re-broadens automatically), so it acts only on
+  classifications at or above the confidence threshold. A single
+  low-confidence misread turn cannot permanently strip capability from the
+  whole session.
+- **Capability-on-demand.** Presets whose tool surface is narrower than the
+  full set carry an `EscalationPolicy` whose `grantable_tools` covers exactly
+  what the preset lacks (e.g. `focused_readonly` → `write`, `bash`). An
+  under-provisioned task recovers per-tool via `escalate_policy` behind the
+  flood guard and `require_human=True` — nothing is granted unless the
+  operator wires an approval callback, and the overlay/parent intersection
+  can only narrow the grantable set further.
 
 ### Adversarial Task Text
 

--- a/tests/capability/test_approvals.py
+++ b/tests/capability/test_approvals.py
@@ -65,11 +65,63 @@ async def test_allowlist_confined_approver_denies_unconfined_request():
 
 
 @pytest.mark.asyncio
-async def test_allowlist_rejects_dotdot_escape():
+async def test_allowlist_rejects_dotdot_escape(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
     approver = AllowlistEscalationApprover(
-        {"write": 10}, allowed_path_prefixes=("/workspace",)
+        {"write": 10}, allowed_path_prefixes=(str(workspace),)
     )
-    assert await approver("t1", "write", ["/workspace/../etc/passwd"], 1) is False
+    escape = str(workspace / ".." / "etc" / "passwd")
+    assert await approver("t1", "write", [escape], 1) is False
+
+
+@pytest.mark.asyncio
+async def test_allowlist_rejects_symlink_escape(tmp_path):
+    """A symlink inside the workspace must not mint an allowed root outside it.
+    Approval uses the same canonical (symlink-resolving) containment as lease
+    enforcement, so /workspace/link -> /etc is 'outside', not 'inside'."""
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    link = workspace / "link"
+    link.symlink_to(outside)
+
+    approver = AllowlistEscalationApprover(
+        {"write": 10}, allowed_path_prefixes=(str(workspace),)
+    )
+    assert await approver("t1", "write", [str(link)], 1) is False
+    assert await approver("t1", "write", [str(link / "passwd")], 1) is False
+
+
+@pytest.mark.asyncio
+async def test_allowlist_accepts_symlink_resolving_inside(tmp_path):
+    workspace = tmp_path / "workspace"
+    (workspace / "src").mkdir(parents=True)
+    link = workspace / "alias"
+    link.symlink_to(workspace / "src")
+
+    approver = AllowlistEscalationApprover(
+        {"write": 10}, allowed_path_prefixes=(str(workspace),)
+    )
+    assert await approver("t1", "write", [str(link / "a.py")], 1) is True
+
+
+# ── unconfined tools (bash-style: no extractable path in calls) ─────────────────
+
+@pytest.mark.asyncio
+async def test_unconfined_tool_granted_only_without_paths(tmp_path):
+    approver = AllowlistEscalationApprover(
+        {"write": 10, "bash": 5},
+        allowed_path_prefixes=(str(tmp_path),),
+        unconfined_tools=("bash",),
+    )
+    # bash: approvable path-free even though the approver is path-confined
+    assert await approver("t1", "bash", [], 3) is True
+    # a paths-carrying bash request would produce an unusable lease — denied
+    assert await approver("t1", "bash", [str(tmp_path)], 3) is False
+    # write still requires confinement
+    assert await approver("t1", "write", [], 1) is False
 
 
 def test_allowlist_constructor_rejects_empty_and_nonpositive():
@@ -77,6 +129,8 @@ def test_allowlist_constructor_rejects_empty_and_nonpositive():
         AllowlistEscalationApprover({})
     with pytest.raises(ValueError):
         AllowlistEscalationApprover({"write": 0})
+    with pytest.raises(ValueError):
+        AllowlistEscalationApprover({"write": 5}, unconfined_tools=("bash",))
 
 
 # ── console_escalation_callback ─────────────────────────────────────────────────
@@ -103,6 +157,18 @@ async def test_console_parses_answer(monkeypatch, answer, expected):
     monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
     monkeypatch.setattr("builtins.input", lambda _prompt: answer)
     assert await console_escalation_callback("t1", "write", [], 5) is expected
+
+
+@pytest.mark.asyncio
+async def test_console_denies_on_terminal_error(monkeypatch):
+    """EOF mid-prompt (closed stream, ^D) is a denial, not an exception."""
+    monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
+
+    def _eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof)
+    assert await console_escalation_callback("t1", "write", [], 5) is False
 
 
 # ── end-to-end: approver drives a require_human grant ───────────────────────────
@@ -140,6 +206,38 @@ async def test_allowlist_approver_grants_require_human_escalation(make_envelope)
     result = await mgr.grant_from_intent(_escalation_event("write"), env, [])
     assert result.get("granted") is True
     assert mgr.covers("write") is True
+
+
+@pytest.mark.asyncio
+async def test_crashing_callback_is_a_denial_with_trace(make_envelope):
+    """A raising approver must become ESCALATION_DENIED with a trace event —
+    never an exception escaping grant_from_intent."""
+    from axor_core.contracts.trace import TraceEventKind
+
+    async def _boom(tool_use_id, tool, paths, max_ops) -> bool:
+        raise RuntimeError("operator callback exploded")
+
+    env = make_envelope()
+    env = dataclasses.replace(
+        env,
+        policy=dataclasses.replace(
+            env.policy,
+            escalation_policy=EscalationPolicy(
+                allow_escalation=True,
+                grantable_tools=("write",),
+                require_human=True,
+            ),
+        ),
+    )
+    mgr = EscalationManager(escalation_callback=_boom)
+    trace: list = []
+    result = await mgr.grant_from_intent(_escalation_event("write"), env, trace)
+
+    assert result.get("granted") is not True
+    assert "callback failed" in result.get("reason", "")
+    assert mgr.covers("write") is False
+    denied = [e for e in trace if e.kind == TraceEventKind.ESCALATION_DENIED]
+    assert len(denied) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/capability/test_approvals.py
+++ b/tests/capability/test_approvals.py
@@ -1,0 +1,164 @@
+"""
+Ready-made escalation approval callbacks (axor_core.capability.approvals).
+
+The callback only answers the approval question; grant bounds (TTL,
+max-use, flood guard) stay in EscalationManager. Everything here must
+fail closed: unknown tool, over-cap ops, out-of-prefix path, unconfined
+request against a confined approver, and a console prompt with no TTY
+all deny.
+"""
+from __future__ import annotations
+
+import dataclasses
+import sys
+
+import pytest
+
+from axor_core.capability.approvals import (
+    AllowlistEscalationApprover,
+    console_escalation_callback,
+)
+from axor_core.contracts.result import ExecutorEvent, ExecutorEventKind
+from axor_core.contracts.policy import EscalationPolicy
+from axor_core.node.escalation import EscalationManager
+
+
+# ── AllowlistEscalationApprover ─────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_allowlist_approves_within_caps():
+    approver = AllowlistEscalationApprover({"write": 10, "bash": 5})
+    assert await approver("t1", "write", [], 10) is True
+    assert await approver("t1", "bash", [], 1) is True
+
+
+@pytest.mark.asyncio
+async def test_allowlist_denies_unknown_tool():
+    approver = AllowlistEscalationApprover({"write": 10})
+    assert await approver("t1", "bash", [], 1) is False
+
+
+@pytest.mark.asyncio
+async def test_allowlist_denies_over_cap_ops():
+    approver = AllowlistEscalationApprover({"write": 5})
+    assert await approver("t1", "write", [], 6) is False
+
+
+@pytest.mark.asyncio
+async def test_allowlist_path_confinement():
+    approver = AllowlistEscalationApprover(
+        {"write": 10}, allowed_path_prefixes=("/workspace",)
+    )
+    assert await approver("t1", "write", ["/workspace/src/a.py"], 1) is True
+    assert await approver("t1", "write", ["/etc/passwd"], 1) is False
+    # one bad path poisons the whole request
+    assert await approver("t1", "write", ["/workspace/a", "/etc/x"], 1) is False
+
+
+@pytest.mark.asyncio
+async def test_allowlist_confined_approver_denies_unconfined_request():
+    approver = AllowlistEscalationApprover(
+        {"write": 10}, allowed_path_prefixes=("/workspace",)
+    )
+    # no paths = unrestricted grant, broader than the confinement allows
+    assert await approver("t1", "write", [], 1) is False
+
+
+@pytest.mark.asyncio
+async def test_allowlist_rejects_dotdot_escape():
+    approver = AllowlistEscalationApprover(
+        {"write": 10}, allowed_path_prefixes=("/workspace",)
+    )
+    assert await approver("t1", "write", ["/workspace/../etc/passwd"], 1) is False
+
+
+def test_allowlist_constructor_rejects_empty_and_nonpositive():
+    with pytest.raises(ValueError):
+        AllowlistEscalationApprover({})
+    with pytest.raises(ValueError):
+        AllowlistEscalationApprover({"write": 0})
+
+
+# ── console_escalation_callback ─────────────────────────────────────────────────
+
+class _FakeStdin:
+    def __init__(self, tty: bool) -> None:
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+@pytest.mark.asyncio
+async def test_console_denies_without_tty(monkeypatch):
+    monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=False))
+    assert await console_escalation_callback("t1", "write", [], 5) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("answer,expected", [
+    ("y", True), ("YES", True), ("n", False), ("", False), ("later", False),
+])
+async def test_console_parses_answer(monkeypatch, answer, expected):
+    monkeypatch.setattr(sys, "stdin", _FakeStdin(tty=True))
+    monkeypatch.setattr("builtins.input", lambda _prompt: answer)
+    assert await console_escalation_callback("t1", "write", [], 5) is expected
+
+
+# ── end-to-end: approver drives a require_human grant ───────────────────────────
+
+def _escalation_event(tool: str, max_ops: int = 3) -> ExecutorEvent:
+    return ExecutorEvent(
+        kind=ExecutorEventKind.TOOL_USE,
+        payload={
+            "tool": "escalate_policy",
+            "tool_use_id": "esc-1",
+            "args": {"tool": tool, "reason": "need write access", "paths": [],
+                     "max_ops": max_ops},
+        },
+        node_id="node-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_allowlist_approver_grants_require_human_escalation(make_envelope):
+    env = make_envelope()
+    env = dataclasses.replace(
+        env,
+        policy=dataclasses.replace(
+            env.policy,
+            escalation_policy=EscalationPolicy(
+                allow_escalation=True,
+                grantable_tools=("write",),
+                require_human=True,
+            ),
+        ),
+    )
+    mgr = EscalationManager(
+        escalation_callback=AllowlistEscalationApprover({"write": 10})
+    )
+    result = await mgr.grant_from_intent(_escalation_event("write"), env, [])
+    assert result.get("granted") is True
+    assert mgr.covers("write") is True
+
+
+@pytest.mark.asyncio
+async def test_allowlist_approver_denies_out_of_list_escalation(make_envelope):
+    env = make_envelope()
+    env = dataclasses.replace(
+        env,
+        policy=dataclasses.replace(
+            env.policy,
+            escalation_policy=EscalationPolicy(
+                allow_escalation=True,
+                grantable_tools=("write", "bash"),
+                require_human=True,
+            ),
+        ),
+    )
+    mgr = EscalationManager(
+        escalation_callback=AllowlistEscalationApprover({"write": 10})
+    )
+    result = await mgr.grant_from_intent(_escalation_event("bash"), env, [])
+    assert result.get("granted") is not True
+    assert mgr.covers("bash") is False

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -20,15 +20,38 @@ class TestGovernedSessionIntegration:
             trace_config=TraceConfig(local_only=True, persist_inputs=False),
         )
 
+    @staticmethod
+    def _confident(session):
+        """Report the heuristic's signal with high confidence: preset
+        selection applies only to classifications the analyzer trusts —
+        an ambiguous one runs fail-closed under safe_fallback."""
+        from types import SimpleNamespace
+        real_analyze = session._analyzer.analyze
+
+        async def _analyze(raw_input):
+            signal, _event = await real_analyze(raw_input)
+            return signal, SimpleNamespace(confidence=0.95)
+
+        session._analyzer.analyze = _analyze
+
     @pytest.mark.asyncio
     async def test_focused_task_selects_correct_policy(self, session):
+        self._confident(session)
         result = await session.run("write a test for the payment endpoint")
         assert result.metadata["policy"] == "focused_generative"
 
     @pytest.mark.asyncio
     async def test_expansive_task_selects_expansive_policy(self, session):
+        self._confident(session)
         result = await session.run("rewrite the entire codebase from Python to Go")
         assert result.metadata["policy"] == "expansive"
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_first_classification_runs_fail_closed(self, session):
+        """Without a confident classification the first turn must not run
+        under a classifier-chosen authority — safe_fallback applies."""
+        result = await session.run("rewrite the entire codebase from Python to Go")
+        assert result.metadata["policy"] == "default"
 
     @pytest.mark.asyncio
     async def test_preset_policy_overrides_analysis(self, session):

--- a/tests/policy/test_analyzer_failsafe.py
+++ b/tests/policy/test_analyzer_failsafe.py
@@ -1,0 +1,102 @@
+"""
+TaskAnalyzer resilience around the external (ML) classifier.
+
+Invariants:
+  1. A broken external classifier degrades to the heuristic result —
+     it never crashes governed execution (classifier-threat-model.md).
+  2. The external classifier's domain head is consumed, not discarded:
+     agent domain > external domain > keyword detection.
+"""
+from __future__ import annotations
+
+import pytest
+
+from axor_core.contracts.policy import (
+    SignalClassifier,
+    TaskComplexity,
+    TaskNature,
+    TaskSignal,
+)
+from axor_core.policy.analyzer import TaskAnalyzer
+
+
+def _signal(raw_input: str, domain: str = "general") -> TaskSignal:
+    return TaskSignal(
+        raw_input=raw_input,
+        complexity=TaskComplexity.MODERATE,
+        nature=TaskNature.MUTATIVE,
+        estimated_scope=5,
+        requires_children=False,
+        requires_mutation=True,
+        domain=domain,
+    )
+
+
+class _RaisingClassifier(SignalClassifier):
+    async def classify(self, raw_input: str) -> tuple[TaskSignal, float]:
+        raise RuntimeError("model file corrupted")
+
+
+class _ConfidentClassifier(SignalClassifier):
+    def __init__(self, domain: str = "general", confidence: float = 0.9) -> None:
+        self._domain = domain
+        self._confidence = confidence
+
+    async def classify(self, raw_input: str) -> tuple[TaskSignal, float]:
+        return _signal(raw_input, domain=self._domain), self._confidence
+
+
+# Low heuristic signal on purpose: no complexity/nature keywords, so the
+# analyzer always escalates to the external classifier.
+_AMBIGUOUS_TASK = "sdrujghs wpoit nrvz qqle"
+
+
+@pytest.mark.asyncio
+async def test_external_classifier_exception_falls_back_to_heuristic():
+    analyzer = TaskAnalyzer(external_classifier=_RaisingClassifier())
+
+    signal, event = await analyzer.analyze(_AMBIGUOUS_TASK)
+
+    assert signal is not None
+    assert event.classifier == "heuristic"
+
+
+@pytest.mark.asyncio
+async def test_external_domain_head_is_used():
+    analyzer = TaskAnalyzer(external_classifier=_ConfidentClassifier(domain="research"))
+
+    signal, event = await analyzer.analyze(_AMBIGUOUS_TASK)
+
+    assert event.classifier == "_ConfidentClassifier"
+    assert signal.domain == "research"
+
+
+@pytest.mark.asyncio
+async def test_external_general_domain_falls_back_to_keywords():
+    analyzer = TaskAnalyzer(external_classifier=_ConfidentClassifier(domain="general"))
+
+    signal, _ = await analyzer.analyze("fix the bug in the parser and debug the test")
+
+    # external won the escalation but declared no domain — keyword detection decides
+    assert signal.domain == "coding"
+
+
+@pytest.mark.asyncio
+async def test_agent_domain_wins_over_external_domain():
+    analyzer = TaskAnalyzer(
+        external_classifier=_ConfidentClassifier(domain="research"),
+        agent_domain="support",
+    )
+
+    signal, _ = await analyzer.analyze(_AMBIGUOUS_TASK)
+
+    assert signal.domain == "support"
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_external_does_not_override_heuristic():
+    analyzer = TaskAnalyzer(external_classifier=_ConfidentClassifier(confidence=0.1))
+
+    _, event = await analyzer.analyze(_AMBIGUOUS_TASK)
+
+    assert event.classifier == "heuristic"

--- a/tests/policy/test_capability_on_demand.py
+++ b/tests/policy/test_capability_on_demand.py
@@ -1,0 +1,84 @@
+"""
+Capability-on-demand: presets whose tool surface is narrower than the full
+set carry an escalation path, so a misclassified task recovers per-tool via
+escalate_policy instead of failing. The path stays fail-closed:
+require_human=True means nothing is granted without an operator-wired
+callback, and grantable_tools never exceeds what the preset lacks.
+"""
+from __future__ import annotations
+
+from axor_core.contracts.policy import (
+    TaskComplexity,
+    TaskNature,
+    TaskSignal,
+)
+from axor_core.policy.selector import PolicySelector
+
+
+def _signal(complexity: TaskComplexity, nature: TaskNature) -> TaskSignal:
+    return TaskSignal(
+        raw_input="x",
+        complexity=complexity,
+        nature=nature,
+        estimated_scope=1,
+        requires_children=False,
+        requires_mutation=nature == TaskNature.MUTATIVE,
+    )
+
+
+def _select(complexity: TaskComplexity, nature: TaskNature):
+    return PolicySelector().select(_signal(complexity, nature))
+
+
+def test_focused_readonly_can_escalate_to_write_and_bash():
+    ep = _select(TaskComplexity.FOCUSED, TaskNature.READONLY).escalation_policy
+    assert ep.allow_escalation is True
+    assert set(ep.grantable_tools) == {"write", "bash"}
+    assert ep.require_human is True  # fail-closed without a callback
+
+
+def test_focused_generative_can_escalate_to_bash():
+    ep = _select(TaskComplexity.FOCUSED, TaskNature.GENERATIVE).escalation_policy
+    assert ep.allow_escalation is True
+    assert set(ep.grantable_tools) == {"bash"}
+    assert ep.require_human is True
+
+
+def test_moderate_readonly_can_escalate_to_write_and_bash():
+    ep = _select(TaskComplexity.MODERATE, TaskNature.READONLY).escalation_policy
+    assert ep.allow_escalation is True
+    assert set(ep.grantable_tools) == {"write", "bash"}
+    assert ep.require_human is True
+
+
+def test_full_surface_presets_grant_nothing():
+    """Presets that already have the full tool surface keep escalation off —
+    there is nothing legitimate to escalate to."""
+    for complexity, nature in [
+        (TaskComplexity.FOCUSED, TaskNature.MUTATIVE),
+        (TaskComplexity.MODERATE, TaskNature.GENERATIVE),
+        (TaskComplexity.MODERATE, TaskNature.MUTATIVE),
+        (TaskComplexity.EXPANSIVE, TaskNature.MUTATIVE),
+    ]:
+        ep = _select(complexity, nature).escalation_policy
+        assert ep.allow_escalation is False, (complexity, nature)
+        assert ep.grantable_tools == ()
+
+
+def test_safe_fallback_can_escalate_to_search_write_bash():
+    ep = PolicySelector().safe_fallback().escalation_policy
+    assert ep.allow_escalation is True
+    assert set(ep.grantable_tools) == {"search", "write", "bash"}
+    assert ep.require_human is True
+
+
+def test_grantable_tools_never_include_spawn():
+    """Escalation may widen the tool surface, never the child topology."""
+    selector = PolicySelector()
+    policies = [
+        selector.select(_signal(c, n))
+        for c in TaskComplexity
+        for n in TaskNature
+    ] + [selector.safe_fallback()]
+    for policy in policies:
+        assert "spawn_child" not in policy.escalation_policy.grantable_tools

--- a/tests/policy/test_capability_on_demand.py
+++ b/tests/policy/test_capability_on_demand.py
@@ -1,18 +1,40 @@
 """
-Capability-on-demand: presets whose tool surface is narrower than the full
-set carry an escalation path, so a misclassified task recovers per-tool via
-escalate_policy instead of failing. The path stays fail-closed:
-require_human=True means nothing is granted without an operator-wired
-callback, and grantable_tools never exceeds what the preset lacks.
+Escalation ceiling is operator authority, never classifier output.
+
+Classifier-selected presets carry NO EscalationPolicy: which capabilities
+may later be granted must not be derived from task text. The operator sets
+the ceiling via GovernedSession(escalation_policy=...) (applied to every
+classifier-selected policy) or an explicit policy.
 """
 from __future__ import annotations
 
+import pytest
+
+from axor_core.capability.executor import CapabilityExecutor
+from axor_core.contracts.mode import ExecutionMode
 from axor_core.contracts.policy import (
+    EscalationPolicy,
     TaskComplexity,
     TaskNature,
     TaskSignal,
 )
 from axor_core.policy.selector import PolicySelector
+from axor_core.worker.session import GovernedSession
+
+from tests.conftest import EchoExecutor
+
+
+def _confident_analyze(session):
+    """Patch the analyzer to report a confident classification so the
+    adaptive baseline is set (ambiguous classifications are per-turn only)."""
+    from types import SimpleNamespace
+    real_analyze = session._analyzer.analyze
+
+    async def _analyze(raw_input: str):
+        signal, _event = await real_analyze(raw_input)
+        return signal, SimpleNamespace(confidence=0.95)
+
+    session._analyzer.analyze = _analyze
 
 
 def _signal(complexity: TaskComplexity, nature: TaskNature) -> TaskSignal:
@@ -26,54 +48,8 @@ def _signal(complexity: TaskComplexity, nature: TaskNature) -> TaskSignal:
     )
 
 
-def _select(complexity: TaskComplexity, nature: TaskNature):
-    return PolicySelector().select(_signal(complexity, nature))
-
-
-def test_focused_readonly_can_escalate_to_write_and_bash():
-    ep = _select(TaskComplexity.FOCUSED, TaskNature.READONLY).escalation_policy
-    assert ep.allow_escalation is True
-    assert set(ep.grantable_tools) == {"write", "bash"}
-    assert ep.require_human is True  # fail-closed without a callback
-
-
-def test_focused_generative_can_escalate_to_bash():
-    ep = _select(TaskComplexity.FOCUSED, TaskNature.GENERATIVE).escalation_policy
-    assert ep.allow_escalation is True
-    assert set(ep.grantable_tools) == {"bash"}
-    assert ep.require_human is True
-
-
-def test_moderate_readonly_can_escalate_to_write_and_bash():
-    ep = _select(TaskComplexity.MODERATE, TaskNature.READONLY).escalation_policy
-    assert ep.allow_escalation is True
-    assert set(ep.grantable_tools) == {"write", "bash"}
-    assert ep.require_human is True
-
-
-def test_full_surface_presets_grant_nothing():
-    """Presets that already have the full tool surface keep escalation off —
-    there is nothing legitimate to escalate to."""
-    for complexity, nature in [
-        (TaskComplexity.FOCUSED, TaskNature.MUTATIVE),
-        (TaskComplexity.MODERATE, TaskNature.GENERATIVE),
-        (TaskComplexity.MODERATE, TaskNature.MUTATIVE),
-        (TaskComplexity.EXPANSIVE, TaskNature.MUTATIVE),
-    ]:
-        ep = _select(complexity, nature).escalation_policy
-        assert ep.allow_escalation is False, (complexity, nature)
-        assert ep.grantable_tools == ()
-
-
-def test_safe_fallback_can_escalate_to_search_write_bash():
-    ep = PolicySelector().safe_fallback().escalation_policy
-    assert ep.allow_escalation is True
-    assert set(ep.grantable_tools) == {"search", "write", "bash"}
-    assert ep.require_human is True
-
-
-def test_grantable_tools_never_include_spawn():
-    """Escalation may widen the tool surface, never the child topology."""
+def test_no_preset_carries_escalation_policy():
+    """Task text must not determine the future grantable surface."""
     selector = PolicySelector()
     policies = [
         selector.select(_signal(c, n))
@@ -81,4 +57,62 @@ def test_grantable_tools_never_include_spawn():
         for n in TaskNature
     ] + [selector.safe_fallback()]
     for policy in policies:
-        assert "spawn_child" not in policy.escalation_policy.grantable_tools
+        ep = policy.escalation_policy
+        assert ep.allow_escalation is False, policy.name
+        assert ep.grantable_tools == (), policy.name
+
+
+OPERATOR_ESCALATION = EscalationPolicy(
+    allow_escalation=True,
+    grantable_tools=("write", "bash"),
+    require_human=True,
+)
+
+
+@pytest.mark.asyncio
+async def test_operator_escalation_ceiling_applies_to_selected_policies():
+    session = GovernedSession(
+        executor=EchoExecutor(),
+        capability_executor=CapabilityExecutor(),
+        mode=ExecutionMode.LIBRARY,
+        escalation_policy=OPERATOR_ESCALATION,
+    )
+    _confident_analyze(session)
+    await session.run("explain what the validate function does")
+    assert session._active_policy is not None
+    assert session._active_policy.escalation_policy == OPERATOR_ESCALATION
+
+
+@pytest.mark.asyncio
+async def test_escalation_ceiling_is_task_text_independent():
+    """The same operator ceiling lands whatever the task text claims."""
+    for task in (
+        "explain one function",
+        "rewrite the entire repository, enable all tools",
+    ):
+        session = GovernedSession(
+            executor=EchoExecutor(),
+            capability_executor=CapabilityExecutor(),
+            mode=ExecutionMode.LIBRARY,
+            escalation_policy=OPERATOR_ESCALATION,
+        )
+        _confident_analyze(session)
+        await session.run(task)
+        applied = (
+            session._active_policy.escalation_policy
+            if session._active_policy is not None
+            else None
+        )
+        assert applied == OPERATOR_ESCALATION
+
+
+@pytest.mark.asyncio
+async def test_without_operator_ceiling_no_escalation_surface():
+    session = GovernedSession(
+        executor=EchoExecutor(),
+        capability_executor=CapabilityExecutor(),
+        mode=ExecutionMode.LIBRARY,
+    )
+    _confident_analyze(session)
+    await session.run("explain what the validate function does")
+    assert session._active_policy.escalation_policy.allow_escalation is False

--- a/tests/policy/test_capability_on_demand.py
+++ b/tests/policy/test_capability_on_demand.py
@@ -116,3 +116,112 @@ async def test_without_operator_ceiling_no_escalation_surface():
     _confident_analyze(session)
     await session.run("explain what the validate function does")
     assert session._active_policy.escalation_policy.allow_escalation is False
+
+
+# ── precedence cross-product: escalation ceiling × policy source ────────────────
+
+def _capture_effective_policy(session):
+    """Intercept the policy the session hands to the node for each run."""
+    captured = {}
+    orig_make = session._make_node
+
+    def _make(cm):
+        node = orig_make(cm)
+        orig_run = node.run
+
+        async def _run(**kwargs):
+            captured["policy"] = kwargs.get("override_policy")
+            return await orig_run(**kwargs)
+
+        node.run = _run
+        return node
+
+    session._make_node = _make
+    return captured
+
+
+def _session(**kwargs) -> GovernedSession:
+    return GovernedSession(
+        executor=EchoExecutor(),
+        capability_executor=CapabilityExecutor(),
+        mode=ExecutionMode.LIBRARY,
+        **kwargs,
+    )
+
+
+from axor_core.contracts.policy import ExecutionPolicy, ToolPolicy  # noqa: E402
+
+DEFAULT_POLICY = ExecutionPolicy(
+    name="operator_default",
+    tool_policy=ToolPolicy(allow_read=True, allow_write=True),
+)
+
+PER_CALL_ESCALATION = EscalationPolicy(
+    allow_escalation=True, grantable_tools=("search",), require_human=True,
+)
+PER_CALL_POLICY = ExecutionPolicy(
+    name="per_call",
+    tool_policy=ToolPolicy(allow_read=True),
+    escalation_policy=PER_CALL_ESCALATION,
+)
+
+
+@pytest.mark.asyncio
+async def test_default_policy_gets_operator_escalation_ceiling():
+    """The README production configuration works as written: the ceiling is
+    applied to default_policy, not silently ignored."""
+    session = _session(
+        default_policy=DEFAULT_POLICY, escalation_policy=OPERATOR_ESCALATION
+    )
+    captured = _capture_effective_policy(session)
+    await session.run("task")
+    assert captured["policy"].name == "operator_default"
+    assert captured["policy"].escalation_policy == OPERATOR_ESCALATION
+
+
+@pytest.mark.asyncio
+async def test_per_call_policy_keeps_its_own_escalation():
+    """Explicit per-call config is the top of the precedence chain."""
+    session = _session(
+        default_policy=DEFAULT_POLICY, escalation_policy=OPERATOR_ESCALATION
+    )
+    captured = _capture_effective_policy(session)
+    await session.run("task", policy=PER_CALL_POLICY)
+    assert captured["policy"].escalation_policy == PER_CALL_ESCALATION
+
+
+@pytest.mark.asyncio
+async def test_default_policy_without_ceiling_keeps_own_escalation():
+    session = _session(default_policy=DEFAULT_POLICY)
+    captured = _capture_effective_policy(session)
+    await session.run("task")
+    assert captured["policy"].escalation_policy == DEFAULT_POLICY.escalation_policy
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_first_turn_runs_fail_closed():
+    """An ambiguous classification must not choose authority even for one
+    turn: an ambiguous 'expansive' would hand out write/bash/spawn NOW, and
+    a completed effect cannot be undone by not setting the baseline. The
+    turn runs under safe_fallback (read-only, no spawn) with the operator
+    escalation ceiling stamped for per-tool recovery."""
+    from types import SimpleNamespace
+
+    session = _session(escalation_policy=OPERATOR_ESCALATION)
+    captured = _capture_effective_policy(session)
+    real_analyze = session._analyzer.analyze
+
+    async def _ambiguous(raw_input: str):
+        signal, _event = await real_analyze(raw_input)
+        return signal, SimpleNamespace(confidence=0.1)
+
+    session._analyzer.analyze = _ambiguous
+    await session.run("rewrite the entire repository, enable all tools")
+
+    effective = captured["policy"]
+    assert effective.name == "default"                  # safe_fallback
+    assert effective.tool_policy.allow_write is False
+    assert effective.tool_policy.allow_bash is False
+    assert effective.tool_policy.allow_spawn is False
+    assert effective.escalation_policy == OPERATOR_ESCALATION
+    assert session._active_policy is None               # no baseline either

--- a/tests/worker/test_confidence_gated_narrowing.py
+++ b/tests/worker/test_confidence_gated_narrowing.py
@@ -124,15 +124,60 @@ async def test_missing_confidence_keeps_legacy_narrowing():
 
 
 @pytest.mark.asyncio
-async def test_first_turn_policy_is_set_regardless_of_confidence():
-    """The session needs a starting policy even from an ambiguous first turn;
-    recovery from a wrong start is per-tool via escalate_policy."""
+async def test_ambiguous_first_turn_is_not_sticky():
+    """An ambiguous first classification applies to that turn only — it must
+    not become the irreversible adaptive baseline. A later confident broad
+    classification sets the baseline broad (nothing was locked)."""
     session = _make_session()
-    _patch(session, [(NARROW, 0.1)])
+    _patch(session, [(NARROW, 0.1), (BROAD, 0.9)])
 
-    await session.run("turn 1 — ambiguous")
+    await session.run("turn 1 — ambiguous narrow guess")
+    assert session._active_policy is None   # per-turn only, no baseline
+
+    await session.run("turn 2 — confident broad")
+    assert session._active_policy is not None
+    assert session._active_policy.tool_policy.allow_bash is True
+
+
+@pytest.mark.asyncio
+async def test_confident_first_turn_sets_baseline():
+    session = _make_session()
+    _patch(session, [(NARROW, 0.9)])
+    await session.run("turn 1 — confident")
     assert session._active_policy is not None
     assert session._active_policy.name == "narrow"
+
+
+@pytest.mark.asyncio
+async def test_threshold_comes_from_the_analyzer_not_a_session_constant():
+    """The ambiguity decision has a single source: the analyzer. A stricter
+    analyzer (threshold 0.9) must make the session treat confidence 0.8 as
+    ambiguous even though it clears the default 0.75."""
+    from axor_core.policy.analyzer import TaskAnalyzer
+
+    session = _make_session()
+    session._analyzer = TaskAnalyzer(escalation_threshold=0.9)
+    _patch(session, [(BROAD, 0.95), (NARROW, 0.8)])
+
+    await session.run("turn 1 — confident broad")
+    assert session._active_policy.tool_policy.allow_bash is True
+
+    await session.run("turn 2 — 0.8 is ambiguous for THIS analyzer")
+    assert session._active_policy.tool_policy.allow_bash is True  # no narrowing
+
+
+@pytest.mark.asyncio
+async def test_lenient_analyzer_threshold_allows_narrowing():
+    """Symmetric case: analyzer threshold 0.6 makes confidence 0.7 confident."""
+    from axor_core.policy.analyzer import TaskAnalyzer
+
+    session = _make_session()
+    session._analyzer = TaskAnalyzer(escalation_threshold=0.6)
+    _patch(session, [(BROAD, 0.95), (NARROW, 0.7)])
+
+    await session.run("turn 1")
+    await session.run("turn 2 — 0.7 clears the configured 0.6")
+    assert session._active_policy.tool_policy.allow_bash is False
 
 
 @pytest.mark.asyncio

--- a/tests/worker/test_confidence_gated_narrowing.py
+++ b/tests/worker/test_confidence_gated_narrowing.py
@@ -1,0 +1,151 @@
+"""
+Confidence-gated adaptive narrowing.
+
+Narrowing is monotonic (test_adaptive_policy.py), so it must only act on a
+classification the analyzer is actually confident about — a single
+low-confidence misread turn must not permanently strip capability from the
+whole session. An analyzer that reports no confidence (custom/patched)
+keeps the legacy always-narrow behaviour.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from axor_core.capability.executor import CapabilityExecutor
+from axor_core.contracts.mode import ExecutionMode
+from axor_core.contracts.policy import (
+    ChildMode,
+    CompressionMode,
+    ContextMode,
+    ExecutionPolicy,
+    ExportMode,
+    TaskComplexity,
+    TaskNature,
+    TaskSignal,
+    ToolPolicy,
+)
+from axor_core.worker.session import GovernedSession
+
+from tests.conftest import EchoExecutor
+
+
+def _policy(name: str, *, allow_bash: bool) -> ExecutionPolicy:
+    return ExecutionPolicy(
+        name=name,
+        derived_from=TaskComplexity.FOCUSED,
+        context_mode=ContextMode.MINIMAL,
+        compression_mode=CompressionMode.BALANCED,
+        child_mode=ChildMode.DENIED,
+        max_child_depth=0,
+        tool_policy=ToolPolicy(
+            allow_read=True,
+            allow_write=True,
+            allow_bash=allow_bash,
+        ),
+        export_mode=ExportMode.SUMMARY,
+    )
+
+
+BROAD = _policy("broad", allow_bash=True)
+NARROW = _policy("narrow", allow_bash=False)
+
+
+def _make_session() -> GovernedSession:
+    return GovernedSession(
+        executor=EchoExecutor(),
+        capability_executor=CapabilityExecutor(),
+        mode=ExecutionMode.LIBRARY,
+    )
+
+
+def _patch(session: GovernedSession, turns: list[tuple[ExecutionPolicy, float | None]]):
+    """Make each run() turn classify to (policy, confidence)."""
+    calls = iter(turns)
+    pending: dict[str, ExecutionPolicy] = {}
+
+    async def _analyze(raw_input: str):
+        policy, confidence = next(calls)
+        pending["policy"] = policy
+        signal = TaskSignal(
+            raw_input=raw_input,
+            complexity=TaskComplexity.FOCUSED,
+            nature=TaskNature.READONLY,
+            estimated_scope=1,
+            requires_children=False,
+            requires_mutation=False,
+        )
+        event = None if confidence is None else SimpleNamespace(confidence=confidence)
+        return signal, event
+
+    def _select(_signal):
+        return pending["policy"]
+
+    session._analyzer.analyze = _analyze
+    session._selector.select = _select
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_reclassification_does_not_narrow():
+    session = _make_session()
+    _patch(session, [(BROAD, 0.9), (NARROW, 0.4)])
+
+    await session.run("turn 1 — confident broad")
+    assert session._active_policy.tool_policy.allow_bash is True
+
+    await session.run("turn 2 — ambiguous narrow guess")
+    # 0.4 < threshold: the guess must not permanently strip bash
+    assert session._active_policy.tool_policy.allow_bash is True
+    assert session._active_policy.name == "broad"
+
+
+@pytest.mark.asyncio
+async def test_high_confidence_reclassification_narrows():
+    session = _make_session()
+    _patch(session, [(BROAD, 0.9), (NARROW, 0.9)])
+
+    await session.run("turn 1")
+    assert session._active_policy.tool_policy.allow_bash is True
+
+    await session.run("turn 2 — confident narrow")
+    assert session._active_policy.tool_policy.allow_bash is False
+
+
+@pytest.mark.asyncio
+async def test_missing_confidence_keeps_legacy_narrowing():
+    """Custom analyzers that return no event still narrow (legacy behaviour)."""
+    session = _make_session()
+    _patch(session, [(BROAD, None), (NARROW, None)])
+
+    await session.run("turn 1")
+    await session.run("turn 2")
+    assert session._active_policy.tool_policy.allow_bash is False
+
+
+@pytest.mark.asyncio
+async def test_first_turn_policy_is_set_regardless_of_confidence():
+    """The session needs a starting policy even from an ambiguous first turn;
+    recovery from a wrong start is per-tool via escalate_policy."""
+    session = _make_session()
+    _patch(session, [(NARROW, 0.1)])
+
+    await session.run("turn 1 — ambiguous")
+    assert session._active_policy is not None
+    assert session._active_policy.name == "narrow"
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_never_broadens_either():
+    """Gating skips narrowing — it must not accidentally widen the surface."""
+    session = _make_session()
+    _patch(session, [(NARROW, 0.9), (BROAD, 0.4), (BROAD, 0.9)])
+
+    await session.run("turn 1 — confident narrow")
+    assert session._active_policy.tool_policy.allow_bash is False
+
+    await session.run("turn 2 — ambiguous broad guess")
+    assert session._active_policy.tool_policy.allow_bash is False
+
+    await session.run("turn 3 — confident broad, still must not widen")
+    assert session._active_policy.tool_policy.allow_bash is False

--- a/tests/worker/test_session_policy_and_escalation_wiring.py
+++ b/tests/worker/test_session_policy_and_escalation_wiring.py
@@ -111,8 +111,19 @@ async def test_per_call_policy_wins_over_default():
 
 @pytest.mark.asyncio
 async def test_without_default_policy_classifier_still_runs():
+    from types import SimpleNamespace
+
     session = _session()
+    real_analyze = session._analyzer.analyze
+
+    async def _analyze(raw_input):
+        signal, _event = await real_analyze(raw_input)
+        return signal, SimpleNamespace(confidence=0.95)
+
+    session._analyzer.analyze = _analyze
     result = await session.run("explain what the function does")
+    # confident classification sets the adaptive baseline (ambiguous ones
+    # are per-turn only and leave it None)
     assert session._active_policy is not None
 
 

--- a/tests/worker/test_session_policy_and_escalation_wiring.py
+++ b/tests/worker/test_session_policy_and_escalation_wiring.py
@@ -1,0 +1,144 @@
+"""
+GovernedSession wiring for the two operator guards:
+
+  1. escalation_callback= — threaded into every node's IntentLoop so
+     require_human escalations can actually be approved.
+  2. default_policy= — session-wide explicit policy; the classifier is
+     bypassed entirely (recommended PRODUCTION posture, nudged by a
+     one-time warning when PRODUCTION derives policy from classification).
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from axor_core.capability.executor import CapabilityExecutor
+from axor_core.contracts.mode import ExecutionMode
+from axor_core.contracts.policy import (
+    ChildMode,
+    CompressionMode,
+    ContextMode,
+    ExecutionPolicy,
+    ExportMode,
+    TaskComplexity,
+    ToolPolicy,
+)
+from axor_core.worker.session import GovernedSession
+
+from tests.conftest import EchoExecutor
+
+
+EXPLICIT = ExecutionPolicy(
+    name="operator_explicit",
+    derived_from=TaskComplexity.FOCUSED,
+    context_mode=ContextMode.MINIMAL,
+    compression_mode=CompressionMode.BALANCED,
+    child_mode=ChildMode.DENIED,
+    max_child_depth=0,
+    tool_policy=ToolPolicy(allow_read=True, allow_write=True),
+    export_mode=ExportMode.SUMMARY,
+)
+
+PER_CALL = ExecutionPolicy(
+    name="per_call_override",
+    derived_from=TaskComplexity.FOCUSED,
+    context_mode=ContextMode.MINIMAL,
+    compression_mode=CompressionMode.BALANCED,
+    child_mode=ChildMode.DENIED,
+    max_child_depth=0,
+    tool_policy=ToolPolicy(allow_read=True),
+    export_mode=ExportMode.SUMMARY,
+)
+
+
+def _session(mode=ExecutionMode.LIBRARY, **kwargs) -> GovernedSession:
+    return GovernedSession(
+        executor=EchoExecutor(),
+        capability_executor=CapabilityExecutor(),
+        mode=mode,
+        **kwargs,
+    )
+
+
+def _forbid_classification(session: GovernedSession) -> None:
+    async def _fail(_raw_input: str):
+        raise AssertionError("classifier must not run when policy is explicit")
+
+    session._analyzer.analyze = _fail
+
+
+# ── escalation_callback wiring ──────────────────────────────────────────────────
+
+def test_escalation_callback_reaches_the_node():
+    async def _cb(tool_use_id, tool, paths, max_ops) -> bool:
+        return True
+
+    session = _session(escalation_callback=_cb)
+    node = session._make_node(session._context_manager)
+    assert node._escalation_callback is _cb
+
+
+def test_no_callback_by_default():
+    session = _session()
+    node = session._make_node(session._context_manager)
+    assert node._escalation_callback is None
+
+
+# ── default_policy ──────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_default_policy_bypasses_classifier():
+    session = _session(default_policy=EXPLICIT)
+    _forbid_classification(session)
+
+    result = await session.run("любая задача на любом языке")
+
+    assert "operator_explicit" in result.output  # EchoExecutor echoes policy name
+    # explicit policy never feeds the adaptive tracker
+    assert session._active_policy is None
+
+
+@pytest.mark.asyncio
+async def test_per_call_policy_wins_over_default():
+    session = _session(default_policy=EXPLICIT)
+    _forbid_classification(session)
+
+    result = await session.run("task", policy=PER_CALL)
+
+    assert "per_call_override" in result.output
+
+
+@pytest.mark.asyncio
+async def test_without_default_policy_classifier_still_runs():
+    session = _session()
+    result = await session.run("explain what the function does")
+    assert session._active_policy is not None
+
+
+# ── PRODUCTION nudge ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_production_warns_once_on_classifier_derived_policy(caplog):
+    session = _session(mode=ExecutionMode.PRODUCTION)
+    with caplog.at_level(logging.WARNING, logger="axor.session"):
+        await session.run("explain what the function does")
+        await session.run("explain another function")
+    warnings = [r for r in caplog.records if "deriving policy from task" in r.message]
+    assert len(warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_production_with_default_policy_does_not_warn(caplog):
+    session = _session(mode=ExecutionMode.PRODUCTION, default_policy=EXPLICIT)
+    with caplog.at_level(logging.WARNING, logger="axor.session"):
+        await session.run("task")
+    assert not [r for r in caplog.records if "deriving policy" in r.message]
+
+
+@pytest.mark.asyncio
+async def test_library_mode_does_not_warn(caplog):
+    session = _session(mode=ExecutionMode.LIBRARY)
+    with caplog.at_level(logging.WARNING, logger="axor.session"):
+        await session.run("explain what the function does")
+    assert not [r for r in caplog.records if "deriving policy" in r.message]


### PR DESCRIPTION
## Scope

Compatibility-window hardening of the **legacy model**, in which classification still selects the initial `ExecutionPolicy`. The structural fix — classification removed from the authority path entirely (`AuthorityPolicy` operator-defined, `ExecutionPlan` classifier-shaped) — is the authority/plan split series (#18–#23); this PR makes the legacy path safe to live with until that series lands and the legacy path is removed in the next major.

## Invariants after this PR

1. **Classifier failure is operational only.** An external (ML) classifier exception logs a warning and degrades to the heuristic result — it never crashes `run()`. The external classifier's domain head is consumed (priority: agent domain → external domain → keyword fallback).
2. **Single ambiguity source.** `TaskAnalyzer.ambiguity_threshold` is the only place the confident/ambiguous boundary is defined; the session reads it and never re-interprets confidence with its own constant (a stricter analyzer at 0.9 makes the session treat 0.8 as ambiguous; a lenient 0.6 accepts 0.7 — both tested).
3. **Ambiguous classification never chooses authority — not even for one turn.** With no confident baseline, the turn runs fail-closed under `safe_fallback` (read-only, no spawn), with the operator escalation ceiling stamped for per-tool recovery. It also never becomes the adaptive baseline; the baseline is set by the first confident classification (which may be broader — nothing was locked). Monotonic narrowing then acts only on confident re-classifications; broadening remains impossible in all paths.
4. **The escalation ceiling is operator authority, never classifier output.** Classifier-selected presets (including `safe_fallback`) carry **no** `EscalationPolicy`. The operator sets the ceiling via `GovernedSession(escalation_policy=...)`, applied with a defined precedence: per-call `policy=` escalation → session `escalation_policy=` (stamped onto `default_policy` **and** classifier-selected policies) → the policy's own (default: disabled). The README production configuration (`default_policy` + `escalation_policy` + approver) works as written.
5. **Escalation approvals are wired and fail-closed.** `GovernedSession(escalation_callback=...)` threads into every node (children inherit). Ready-made approvers in `capability/approvals.py`: `AllowlistEscalationApprover` (canonical symlink/`..`-resolving path containment — same model as lease enforcement; `unconfined_tools` opt-in for tools like bash whose calls expose no checkable path) and `console_escalation_callback` (TTY-only). A raising approver is a proper `ESCALATION_DENIED` with a trace event.
6. **`default_policy=`** is a compatibility/security guard (it bypasses classification entirely, which also disables task-aware planning); PRODUCTION logs a one-time warning when policy is classifier-derived.

## Consequence made explicit

The heuristic's confidence rarely clears the analyzer threshold, so heuristic-only first turns run fail-closed under `safe_fallback`; preset selection applies to classifications the analyzer trusts (e.g. an ML classifier). Integration tests updated accordingly, plus a dedicated fail-closed test.

## Tests

Cross-product precedence (default_policy × escalation_policy × per-call policy × ambiguous fallback), non-default analyzer thresholds in both directions, ambiguous-turn fail-closed effective policy (`write`/`bash`/`spawn` all denied even for "rewrite the entire repository, enable all tools"), non-sticky ambiguity regression (ambiguous narrow → confident broad does not stay narrow), approver semantics (symlink escape, unconfined tools, crashing callback), analyzer fail-closed, domain priority chain.

Full suite: **1071 passed, 1 skipped, 8 xfailed**; lint-imports and docs check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjJ844CtPJFJcoMqanaobo