### PR TITLE
Authority/plan split — PR A: types and compatibility layer

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -63,3 +63,32 @@ source_modules =
     axor_core.node.canonicalizer
 forbidden_modules =
     axor_core.kernel.adjudicator
+
+# Authority/plan separation (RFC: task classification must not determine
+# authority). Enforcement surfaces decide on AuthorityPolicy and structural
+# facts only — an ExecutionPlan import there would be a channel through which
+# an untrusted task classification could reach an allow/deny decision.
+# (Extend source_modules with axor_core.planning when that package lands.)
+[importlinter:contract:authority-plan-separation]
+name = Enforcement surfaces must not import execution planning
+type = forbidden
+source_modules =
+    axor_core.capability
+    axor_core.security
+    axor_core.governor
+    axor_core.kernel
+    axor_core.taint
+    axor_core.degradation
+forbidden_modules =
+    axor_core.contracts.planning
+
+# The reverse direction: the planning layer must not be able to construct
+# authority. A planner that could import AuthorityPolicy could smuggle a
+# classifier-derived authority object into the session wiring.
+[importlinter:contract:planning-non-authoritative]
+name = Planning layer must not import authority constructors
+type = forbidden
+source_modules =
+    axor_core.contracts.planning
+forbidden_modules =
+    axor_core.contracts.authority

--- a/axor_core/__init__.py
+++ b/axor_core/__init__.py
@@ -82,6 +82,14 @@ _LAZY = {
     "make_token": "axor_core.contracts.cancel",
     "SignalClassifier": "axor_core.contracts.policy",
     "ExecutionPolicy": "axor_core.contracts.policy",
+    "AuthorityPolicy": "axor_core.contracts.authority",
+    "ChildAuthorityPolicy": "axor_core.contracts.authority",
+    "ExportAuthorityPolicy": "axor_core.contracts.authority",
+    "ExecutionPlan": "axor_core.contracts.planning",
+    "RetrievalBreadth": "axor_core.contracts.planning",
+    "DecompositionPreference": "axor_core.contracts.planning",
+    "ResourceBudget": "axor_core.contracts.planning",
+    "split_legacy_policy": "axor_core.policy.legacy",
     "TaskSignal": "axor_core.contracts.policy",
     "TaskComplexity": "axor_core.contracts.policy",
     "TaskNature": "axor_core.contracts.policy",
@@ -134,6 +142,13 @@ if TYPE_CHECKING:  # static visibility for type checkers / IDEs (not loaded at r
     from axor_core.contracts.policy import (
         SignalClassifier, ExecutionPolicy, TaskSignal, TaskComplexity, TaskNature,
     )
+    from axor_core.contracts.authority import (
+        AuthorityPolicy, ChildAuthorityPolicy, ExportAuthorityPolicy,
+    )
+    from axor_core.contracts.planning import (
+        ExecutionPlan, RetrievalBreadth, DecompositionPreference, ResourceBudget,
+    )
+    from axor_core.policy.legacy import split_legacy_policy
     from axor_core.contracts.result import ExecutionResult, TokenUsage
     from axor_core.contracts.extension import ExtensionLoader, ExtensionBundle
     from axor_core.contracts.trace import TraceConfig
@@ -154,6 +169,9 @@ __all__ = [
     "CancelToken", "CancelReason", "make_token",
     "SignalClassifier",
     "ExecutionPolicy",
+    "AuthorityPolicy", "ChildAuthorityPolicy", "ExportAuthorityPolicy",
+    "ExecutionPlan", "RetrievalBreadth", "DecompositionPreference",
+    "ResourceBudget", "split_legacy_policy",
     "TaskSignal", "TaskComplexity", "TaskNature",
     "ExecutionResult", "TokenUsage",
     "ExtensionLoader", "ExtensionBundle",

--- a/axor_core/contracts/__init__.py
+++ b/axor_core/contracts/__init__.py
@@ -36,6 +36,18 @@ from axor_core.contracts.policy import (
     ChildMode,
     ToolPolicy,
 )
+from axor_core.contracts.authority import (
+    AuthorityPolicy,
+    ChildAuthorityPolicy,
+    ExportAuthorityPolicy,
+)
+from axor_core.contracts.planning import (
+    DecompositionPreference,
+    ExecutionPlan,
+    ResourceBudget,
+    RetrievalBreadth,
+    NEUTRAL_PLAN,
+)
 from axor_core.contracts.canonical import CanonicalizedIntent
 from axor_core.contracts.mode import ExecutionMode
 from axor_core.contracts.envelope import (
@@ -115,6 +127,9 @@ __all__ = [
     # context
     "ContextView", "ContextFragment", "LineageSummary", "RawExecutionState",
     # policy
+    "AuthorityPolicy", "ChildAuthorityPolicy", "ExportAuthorityPolicy",
+    "ExecutionPlan", "RetrievalBreadth", "DecompositionPreference",
+    "ResourceBudget", "NEUTRAL_PLAN",
     "TaskSignal", "TaskComplexity", "TaskNature", "SignalClassifier",
     "ExecutionPolicy", "EscalationPolicy", "PolicyDecision", "PolicyDecisionKind",
     "ContextMode", "CompressionMode", "ExportMode", "ChildMode", "ToolPolicy",

--- a/axor_core/contracts/authority.py
+++ b/axor_core/contracts/authority.py
@@ -1,0 +1,89 @@
+"""AuthorityPolicy — the trusted, operator-defined half of governance.
+
+Authority answers one question: which effects may this agent produce AT ALL.
+It must originate only from a trusted source (operator configuration,
+application code, an authenticated control plane, a validated parent-node
+ceiling, an explicit per-run override, or an approved capability lease) —
+never from an interpretation of the task text.
+
+The advisory half — how to execute efficiently — lives in
+:mod:`axor_core.contracts.planning` (``ExecutionPlan``). The two are
+deliberately separate types so that the task classifier can influence
+planning without any code path existing through which it could influence
+authority. Import-linter contracts (``authority-plan-separation``,
+``planning-non-authoritative`` in ``.importlinter``) pin the boundary.
+
+During the migration window the legacy :class:`ExecutionPolicy` (which mixes
+both concerns) remains the runtime object; :mod:`axor_core.policy.legacy`
+converts between the models.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from axor_core.contracts.canonical import ConsequenceClass
+from axor_core.contracts.policy import (
+    EscalationPolicy,
+    ExportMode,
+    ToolPolicy,
+)
+
+
+@dataclass(frozen=True)
+class ChildAuthorityPolicy:
+    """The authority portion of child-node topology.
+
+    ``allow_spawn`` grants only the RIGHT to issue ``spawn_child`` — whether
+    decomposition is a good idea for a given task is a planning concern
+    (``ExecutionPlan.decomposition``) and carries no permission.
+
+    The legacy ``ChildMode`` mixed both: DENIED/SHALLOW/ALLOWED was
+    simultaneously a permission and a planning shape. Here SHALLOW is simply
+    ``allow_spawn=True, max_depth=1``; nesting is a consequence of depth,
+    not a separate mode.
+    """
+
+    allow_spawn: bool = False
+    max_depth: int = 0
+    max_children_per_node: int | None = None
+
+
+@dataclass(frozen=True)
+class ExportAuthorityPolicy:
+    """The security-sensitive ceiling on export.
+
+    ``ExportMode`` forms a total order in the current implementation —
+    allowed-field sets chain RESTRICTED {} ⊂ SUMMARY {output} ⊂ FILTERED
+    {output, metadata} ⊂ FULL, and the token caps are monotone (see
+    ``axor_core.node.envelope``); ``tests/invariants`` pins the chain. A
+    planner may pick a mode at or below ``max_mode`` (formatting is a
+    planning choice); it can never pick above it.
+    """
+
+    max_mode: ExportMode = ExportMode.SUMMARY
+
+
+@dataclass(frozen=True)
+class AuthorityPolicy:
+    """Trusted, operator-defined authority for one execution (or session).
+
+    Every field here is security-sensitive: tools, filesystem ceiling,
+    consequence ceiling, child topology rights, escalation rules, export
+    ceiling, passthrough commands and model-switch rights. None of them may
+    ever be derived from task classification (architectural invariant I1 —
+    classification is non-authoritative).
+    """
+
+    name: str = "standard"
+    tool_policy: ToolPolicy = field(default_factory=ToolPolicy)
+    # Filesystem ceiling — empty tuple means "no path restriction"; when set,
+    # every path-bearing tool call must resolve within one of these roots.
+    allowed_paths: tuple[str, ...] = field(default_factory=tuple)
+    # The most irreversible action class permitted unattended (without a
+    # governance/human gate).
+    max_unattended_consequence: ConsequenceClass = ConsequenceClass.CONSEQUENTIAL
+    child_authority: ChildAuthorityPolicy = field(default_factory=ChildAuthorityPolicy)
+    escalation_policy: EscalationPolicy = field(default_factory=EscalationPolicy)
+    export_policy: ExportAuthorityPolicy = field(default_factory=ExportAuthorityPolicy)
+    allowed_passthrough_commands: tuple[str, ...] = field(default_factory=tuple)
+    allow_model_switch: bool = False

--- a/axor_core/contracts/planning.py
+++ b/axor_core/contracts/planning.py
@@ -1,0 +1,98 @@
+"""ExecutionPlan — the advisory, optimization-only half of governance.
+
+A plan answers one question: how to execute the task efficiently — how much
+context to load, how aggressively to compress it, whether decomposition is
+worth it, what resources to reserve. A plan grants nothing and overrides no
+authority check: every field here can be derived from an untrusted task
+classification, because the worst a wrong plan can do is waste resources
+(bounded by :class:`ResourceBudget`), never produce an effect the operator
+did not authorize.
+
+The trusted half — what the agent may do at all — lives in
+:mod:`axor_core.contracts.authority` (``AuthorityPolicy``). This module must
+never import authority constructors; the ``planning-non-authoritative``
+import-linter contract pins that direction, and ``authority-plan-separation``
+pins the reverse (enforcement surfaces never read planning types).
+
+ExecutionPlan deliberately has NO: ToolPolicy, allowed_paths, consequence
+ceiling, escalation rules, allow_spawn, human-approval policy, model-switch
+authority, or passthrough authority.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from axor_core.contracts.policy import CompressionMode, ContextMode
+
+
+class RetrievalBreadth(str, Enum):
+    NARROW = "narrow"
+    MODERATE = "moderate"
+    BROAD = "broad"
+
+
+class DecompositionPreference(str, Enum):
+    """Whether the planner thinks child decomposition is worth it.
+
+    A preference, not a permission: PREFER does not grant spawn (that is
+    ``ChildAuthorityPolicy.allow_spawn``), and AVOID does not deny it — an
+    agent that spawns anyway is judged by the authority gates alone.
+    """
+
+    AVOID = "avoid"
+    ALLOW = "allow"
+    PREFER = "prefer"
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """Advisory execution shape for one task.
+
+    ``source`` records where the plan came from ("default", "operator",
+    "task_classifier", "legacy_split", ...) and ``confidence`` the
+    classifier's confidence when applicable — both are telemetry, not
+    decision inputs for any enforcement gate.
+    """
+
+    name: str = "default"
+    context_mode: ContextMode = ContextMode.MODERATE
+    compression_mode: CompressionMode = CompressionMode.BALANCED
+    retrieval_breadth: RetrievalBreadth = RetrievalBreadth.MODERATE
+    decomposition: DecompositionPreference = DecompositionPreference.ALLOW
+    # Planning hint for child topology — clamped by the authority's
+    # child_authority.max_depth at spawn time, never a grant.
+    suggested_child_depth: int = 0
+    child_context_fraction: float = 0.0   # 0.0 = no inheritance, 1.0 = full
+    expected_scope: int | None = None     # approximate files/modules affected
+    token_reservation: int | None = None
+    source: str = "default"
+    confidence: float | None = None
+
+
+NEUTRAL_PLAN = ExecutionPlan(name="neutral", source="default")
+"""Applied when no classifier/planner is configured or classification fails.
+
+Classifier failure is operational only (invariant I6): it degrades to this
+plan — it never stops governed execution, never changes authority, and never
+produces a capability denial.
+"""
+
+
+@dataclass(frozen=True)
+class ResourceBudget:
+    """Hard ceilings on what a plan may consume. ``None`` = unlimited.
+
+    Plans may expand and shrink dynamically (planning is not monotonic), but
+    only within these ceilings — they are what bounds the availability blast
+    radius of an adversarially inflated plan (a prompt-injected "this is a
+    repository-wide task" can at most spend up to the budget, never widen
+    the capability surface).
+    """
+
+    max_context_tokens: int | None = None
+    max_retrieval_items: int | None = None
+    max_children: int | None = None
+    max_plan_expansions: int | None = None
+    max_token_reservation: int | None = None
+    max_concurrency: int | None = None

--- a/axor_core/policy/legacy.py
+++ b/axor_core/policy/legacy.py
@@ -1,0 +1,132 @@
+"""Legacy adapter between ExecutionPolicy and (AuthorityPolicy, ExecutionPlan).
+
+The legacy :class:`ExecutionPolicy` mixes trusted authority with advisory
+execution planning in one object. This module is the single place that knows
+how to split it — every field lands on exactly one side:
+
+Authority fields (security-sensitive):
+    tool_policy, allowed_paths, max_unattended_consequence,
+    escalation_policy, allowed_passthrough_commands, allow_model_switch,
+    the permission portion of child_mode/max_child_depth,
+    the ceiling portion of export_mode.
+
+Plan fields (optimization-only):
+    context_mode, compression_mode, child_context_fraction,
+    the shape portion of child_mode/max_child_depth (decomposition
+    preference / suggested depth), derived_from (as scope telemetry).
+
+``merge_to_legacy_policy`` is the inverse, used by the migration-window
+compatibility layer and by the equivalence tests: for every shipped preset,
+``merge(split(p)) == p`` exactly.
+
+Known, documented normalization (not representable in the new model):
+``ChildMode.SHALLOW`` with ``max_child_depth > 1`` — SHALLOW's authority
+meaning IS depth ≤ 1, so such a legacy policy is contradictory; it
+normalizes to ALLOWED at the same depth (permission-equivalent: the depth
+ceiling is what the spawn gate enforces).
+"""
+from __future__ import annotations
+
+from axor_core.contracts.authority import (
+    AuthorityPolicy,
+    ChildAuthorityPolicy,
+    ExportAuthorityPolicy,
+)
+from axor_core.contracts.planning import (
+    DecompositionPreference,
+    ExecutionPlan,
+    RetrievalBreadth,
+)
+from axor_core.contracts.policy import (
+    ChildMode,
+    ContextMode,
+    ExecutionPolicy,
+    TaskComplexity,
+)
+
+# derived_from is a TaskComplexity tag with a canonical scope estimate (the
+# same table HeuristicClassifier and TaskSignalClassifier use). The plan
+# carries the scope number; the inverse map restores the tag on merge.
+_COMPLEXITY_TO_SCOPE: dict[TaskComplexity, int] = {
+    TaskComplexity.FOCUSED: 1,
+    TaskComplexity.MODERATE: 5,
+    TaskComplexity.EXPANSIVE: 999,
+}
+_SCOPE_TO_COMPLEXITY = {v: k for k, v in _COMPLEXITY_TO_SCOPE.items()}
+
+_CONTEXT_TO_BREADTH: dict[ContextMode, RetrievalBreadth] = {
+    ContextMode.MINIMAL: RetrievalBreadth.NARROW,
+    ContextMode.MODERATE: RetrievalBreadth.MODERATE,
+    ContextMode.BROAD: RetrievalBreadth.BROAD,
+}
+
+_CHILD_MODE_TO_DECOMPOSITION: dict[ChildMode, DecompositionPreference] = {
+    ChildMode.DENIED: DecompositionPreference.AVOID,
+    ChildMode.SHALLOW: DecompositionPreference.ALLOW,
+    ChildMode.ALLOWED: DecompositionPreference.PREFER,
+}
+
+
+def split_legacy_policy(
+    policy: ExecutionPolicy,
+) -> tuple[AuthorityPolicy, ExecutionPlan]:
+    """Split a legacy ExecutionPolicy into its authority and plan halves."""
+    authority = AuthorityPolicy(
+        name=policy.name,
+        tool_policy=policy.tool_policy,
+        allowed_paths=tuple(policy.allowed_paths or ()),
+        max_unattended_consequence=policy.max_unattended_consequence,
+        child_authority=ChildAuthorityPolicy(
+            allow_spawn=policy.child_mode != ChildMode.DENIED,
+            max_depth=policy.max_child_depth,
+        ),
+        escalation_policy=policy.escalation_policy,
+        export_policy=ExportAuthorityPolicy(max_mode=policy.export_mode),
+        allowed_passthrough_commands=tuple(policy.allowed_passthrough_commands or ()),
+        allow_model_switch=policy.allow_model_switch,
+    )
+    plan = ExecutionPlan(
+        name=policy.name,
+        context_mode=policy.context_mode,
+        compression_mode=policy.compression_mode,
+        retrieval_breadth=_CONTEXT_TO_BREADTH[policy.context_mode],
+        decomposition=_CHILD_MODE_TO_DECOMPOSITION[policy.child_mode],
+        suggested_child_depth=policy.max_child_depth,
+        child_context_fraction=policy.child_context_fraction,
+        expected_scope=_COMPLEXITY_TO_SCOPE.get(policy.derived_from),
+        source="legacy_split",
+    )
+    return authority, plan
+
+
+def merge_to_legacy_policy(
+    authority: AuthorityPolicy,
+    plan: ExecutionPlan,
+) -> ExecutionPolicy:
+    """Inverse of :func:`split_legacy_policy` (up to the documented SHALLOW
+    normalization). Exists for the migration-window compatibility layer and
+    the split/merge equivalence tests."""
+    if not authority.child_authority.allow_spawn:
+        child_mode = ChildMode.DENIED
+    elif authority.child_authority.max_depth <= 1:
+        child_mode = ChildMode.SHALLOW
+    else:
+        child_mode = ChildMode.ALLOWED
+    return ExecutionPolicy(
+        name=authority.name,
+        derived_from=_SCOPE_TO_COMPLEXITY.get(
+            plan.expected_scope, TaskComplexity.FOCUSED
+        ),
+        context_mode=plan.context_mode,
+        compression_mode=plan.compression_mode,
+        child_mode=child_mode,
+        max_child_depth=authority.child_authority.max_depth,
+        tool_policy=authority.tool_policy,
+        allowed_paths=authority.allowed_paths,
+        export_mode=authority.export_policy.max_mode,
+        child_context_fraction=plan.child_context_fraction,
+        max_unattended_consequence=authority.max_unattended_consequence,
+        escalation_policy=authority.escalation_policy,
+        allowed_passthrough_commands=authority.allowed_passthrough_commands,
+        allow_model_switch=authority.allow_model_switch,
+    )

--- a/tests/contracts/test_authority_plan_split.py
+++ b/tests/contracts/test_authority_plan_split.py
@@ -1,0 +1,222 @@
+"""
+PR A of the authority/plan split (RFC: task classification must not
+determine authority): the new types and the legacy adapter.
+
+Invariants pinned here:
+  * split/merge round-trips every shipped preset byte-identically (§22.7);
+  * every legacy field lands on exactly one side, and ExecutionPlan carries
+    no authority-bearing field at all;
+  * ChildMode decomposes into permission (ChildAuthorityPolicy) + shape
+    (DecompositionPreference), with the one documented normalization;
+  * ExportMode is a total order (the precondition for a single max_mode
+    export ceiling, RFC Q1).
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from axor_core.contracts.authority import (
+    AuthorityPolicy,
+    ChildAuthorityPolicy,
+    ExportAuthorityPolicy,
+)
+from axor_core.contracts.planning import (
+    NEUTRAL_PLAN,
+    DecompositionPreference,
+    ExecutionPlan,
+    ResourceBudget,
+    RetrievalBreadth,
+)
+from axor_core.contracts.policy import (
+    ChildMode,
+    EscalationPolicy,
+    ExecutionPolicy,
+    ExportMode,
+    TaskComplexity,
+    TaskNature,
+    TaskSignal,
+    ToolPolicy,
+)
+from axor_core.policy.legacy import merge_to_legacy_policy, split_legacy_policy
+from axor_core.policy.selector import PolicySelector
+from axor_core.policy import presets as policy_presets
+
+
+def _signal(complexity: TaskComplexity, nature: TaskNature) -> TaskSignal:
+    return TaskSignal(
+        raw_input="x",
+        complexity=complexity,
+        nature=nature,
+        estimated_scope=1,
+        requires_children=False,
+        requires_mutation=nature == TaskNature.MUTATIVE,
+    )
+
+
+def _all_shipped_presets() -> list[ExecutionPolicy]:
+    selector = PolicySelector()
+    from_selector = [
+        selector.select(_signal(c, n))
+        for c in TaskComplexity
+        for n in TaskNature
+    ] + [selector.safe_fallback()]
+    from_presets = [
+        policy_presets.get(name)
+        for name in ("readonly", "sandboxed", "standard", "federated",
+                     "research", "support", "analysis")
+    ]
+    return from_selector + from_presets
+
+
+# ── split/merge equivalence (§22.7) ─────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "policy", _all_shipped_presets(), ids=lambda p: p.name
+)
+def test_split_merge_round_trips_every_shipped_preset(policy):
+    authority, plan = split_legacy_policy(policy)
+    assert merge_to_legacy_policy(authority, plan) == policy
+
+
+def test_shallow_with_deep_ceiling_normalizes_to_allowed():
+    """The one documented lossy case: SHALLOW with max_child_depth > 1 is
+    contradictory legacy config (SHALLOW means depth ≤ 1); it normalizes to
+    ALLOWED at the same depth — permission-equivalent for the spawn gate."""
+    contradictory = ExecutionPolicy(
+        name="weird", child_mode=ChildMode.SHALLOW, max_child_depth=3,
+    )
+    authority, plan = split_legacy_policy(contradictory)
+    merged = merge_to_legacy_policy(authority, plan)
+    assert merged.child_mode == ChildMode.ALLOWED
+    assert merged.max_child_depth == 3
+    assert dataclasses.replace(merged, child_mode=ChildMode.SHALLOW) == contradictory
+
+
+# ── field placement ─────────────────────────────────────────────────────────────
+
+_AUTHORITY_BEARING_FIELDS = {
+    "tool_policy", "allowed_paths", "max_unattended_consequence",
+    "escalation_policy", "allow_spawn", "allowed_passthrough_commands",
+    "allow_model_switch", "export_mode", "max_mode", "require_human",
+}
+
+
+def test_execution_plan_carries_no_authority_fields():
+    plan_fields = {f.name for f in dataclasses.fields(ExecutionPlan)}
+    leaked = plan_fields & _AUTHORITY_BEARING_FIELDS
+    assert not leaked, f"authority-bearing fields leaked into ExecutionPlan: {leaked}"
+
+
+def test_split_puts_every_authority_field_in_authority():
+    policy = ExecutionPolicy(
+        name="probe",
+        tool_policy=ToolPolicy(allow_read=True, allow_write=True, allow_bash=True),
+        allowed_paths=("/workspace",),
+        child_mode=ChildMode.ALLOWED,
+        max_child_depth=2,
+        export_mode=ExportMode.FILTERED,
+        escalation_policy=EscalationPolicy(
+            allow_escalation=True, grantable_tools=("bash",),
+        ),
+        allowed_passthrough_commands=("status",),
+        allow_model_switch=True,
+    )
+    authority, plan = split_legacy_policy(policy)
+
+    assert authority.tool_policy == policy.tool_policy
+    assert authority.allowed_paths == ("/workspace",)
+    assert authority.max_unattended_consequence == policy.max_unattended_consequence
+    assert authority.escalation_policy == policy.escalation_policy
+    assert authority.export_policy == ExportAuthorityPolicy(max_mode=ExportMode.FILTERED)
+    assert authority.child_authority == ChildAuthorityPolicy(
+        allow_spawn=True, max_depth=2,
+    )
+    assert authority.allowed_passthrough_commands == ("status",)
+    assert authority.allow_model_switch is True
+
+
+def test_split_puts_planning_fields_in_plan():
+    policy = PolicySelector().select(
+        _signal(TaskComplexity.MODERATE, TaskNature.GENERATIVE)
+    )
+    _, plan = split_legacy_policy(policy)
+
+    assert plan.context_mode == policy.context_mode
+    assert plan.compression_mode == policy.compression_mode
+    assert plan.child_context_fraction == policy.child_context_fraction
+    assert plan.suggested_child_depth == policy.max_child_depth
+    assert plan.retrieval_breadth == RetrievalBreadth.MODERATE
+    assert plan.decomposition == DecompositionPreference.ALLOW
+    assert plan.expected_scope == 5
+    assert plan.source == "legacy_split"
+
+
+# ── child mode decomposition ────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("child_mode,depth,allow_spawn,decomposition", [
+    (ChildMode.DENIED, 0, False, DecompositionPreference.AVOID),
+    (ChildMode.SHALLOW, 1, True, DecompositionPreference.ALLOW),
+    (ChildMode.ALLOWED, 3, True, DecompositionPreference.PREFER),
+])
+def test_child_mode_splits_into_permission_and_shape(
+    child_mode, depth, allow_spawn, decomposition
+):
+    policy = ExecutionPolicy(child_mode=child_mode, max_child_depth=depth)
+    authority, plan = split_legacy_policy(policy)
+    assert authority.child_authority.allow_spawn is allow_spawn
+    assert authority.child_authority.max_depth == depth
+    assert plan.decomposition == decomposition
+    assert plan.suggested_child_depth == depth
+
+
+# ── export lattice (RFC Q1 precondition) ────────────────────────────────────────
+
+def test_export_mode_is_a_total_order():
+    """A single max_mode export ceiling is sound only while ExportMode's
+    allowed-field sets form a chain and token caps are monotone."""
+    from axor_core.node.envelope import _EXPORT_ALLOWED_FIELDS, _EXPORT_MAX_TOKENS
+
+    chain = [ExportMode.RESTRICTED, ExportMode.SUMMARY,
+             ExportMode.FILTERED, ExportMode.FULL]
+    for narrower, wider in zip(chain, chain[1:]):
+        assert _EXPORT_ALLOWED_FIELDS[narrower] < _EXPORT_ALLOWED_FIELDS[wider], (
+            f"{narrower} must expose strictly fewer fields than {wider}"
+        )
+        n_cap = _EXPORT_MAX_TOKENS[narrower]
+        w_cap = _EXPORT_MAX_TOKENS[wider]
+        assert w_cap is None or (n_cap is not None and n_cap < w_cap), (
+            f"{narrower} token cap must be below {wider}"
+        )
+
+
+# ── defaults ────────────────────────────────────────────────────────────────────
+
+def test_neutral_plan_is_moderate_everything():
+    assert NEUTRAL_PLAN.name == "neutral"
+    assert NEUTRAL_PLAN.retrieval_breadth == RetrievalBreadth.MODERATE
+    assert NEUTRAL_PLAN.decomposition == DecompositionPreference.ALLOW
+    assert NEUTRAL_PLAN.suggested_child_depth == 0
+
+
+def test_default_authority_is_restrictive():
+    authority = AuthorityPolicy()
+    assert authority.child_authority.allow_spawn is False
+    assert authority.escalation_policy.allow_escalation is False
+    assert authority.export_policy.max_mode == ExportMode.SUMMARY
+    assert authority.allow_model_switch is False
+
+
+def test_resource_budget_defaults_to_unlimited():
+    budget = ResourceBudget()
+    assert all(
+        getattr(budget, f.name) is None for f in dataclasses.fields(ResourceBudget)
+    )
+
+
+def test_new_types_are_frozen():
+    for instance in (AuthorityPolicy(), ChildAuthorityPolicy(),
+                     ExportAuthorityPolicy(), ExecutionPlan(), ResourceBudget()):
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(instance, "name", "x")


### PR DESCRIPTION
First PR of the authority/execution-planning separation RFC (*task classification may optimize execution but must not determine agent authority*). **Purely additive — no runtime semantics change.** Sequence: A (this) → B (envelope split) → C (planner migration) → D (session API) → E (dynamic replanning) → F (docs/deprecation).

## What's added

### `contracts/authority.py` — the trusted half
- **`AuthorityPolicy`** — operator-defined authority: `tool_policy`, `allowed_paths`, `max_unattended_consequence`, `child_authority`, `escalation_policy`, `export_policy`, `allowed_passthrough_commands`, `allow_model_switch`. Every field is security-sensitive; none may ever derive from task classification (invariant I1).
- **`ChildAuthorityPolicy`** — `allow_spawn` is the *right* to spawn, not a plan; legacy `SHALLOW` decomposes into `allow_spawn=True, max_depth=1` (nesting is a consequence of depth, not a separate mode).
- **`ExportAuthorityPolicy`** — a single `max_mode` ceiling. Sound because `ExportMode` is a total order in the current implementation (allowed-field sets chain `{} ⊂ {output} ⊂ {output, metadata} ⊂ full`, token caps monotone) — RFC open question Q1 resolved and pinned by a lattice-law test.

### `contracts/planning.py` — the advisory half
- **`ExecutionPlan`** — context/compression/retrieval breadth/decomposition preference/suggested depth/token reservation, plus `source` and `confidence` telemetry. Deliberately carries **no** authority-bearing field (asserted structurally in tests).
- **`NEUTRAL_PLAN`** — the classifier-failure fallback (invariant I6: classifier failure is operational only).
- **`ResourceBudget`** — the ceilings (context tokens, retrieval items, children, plan expansions, reservation, concurrency) that bound an adversarially inflated plan. This was referenced but undefined in the RFC (§12.2/§21.4) — defined here so PR E has a stable type.

### `policy/legacy.py` — the compatibility layer
`split_legacy_policy()` / `merge_to_legacy_policy()` — the single place that knows which legacy `ExecutionPolicy` field belongs to which side (RFC §18.2 mapping). Round-trips **every shipped preset byte-identically** (§22.7). One documented normalization: `SHALLOW` with `max_child_depth > 1` is contradictory legacy config and normalizes to `ALLOWED` at the same depth (permission-equivalent — the depth ceiling is what the spawn gate enforces).

### `.importlinter` — the boundary, pinned from day one (§10.3/§22.9)
- `authority-plan-separation`: enforcement surfaces (`capability`, `security`, `governor`, `kernel`, `taint`, `degradation`) must not import `contracts.planning`.
- `planning-non-authoritative`: `contracts.planning` must not import authority constructors.

Both extend automatically as migration PRs land (`axor_core.planning` package joins the source list in PR C).

## Tests

`tests/contracts/test_authority_plan_split.py` (29 tests): preset round-trip equivalence over all 9 selector presets + `safe_fallback` + the 7 `policy/presets` module presets; field-placement assertions (no authority field leaks into `ExecutionPlan`); `ChildMode` decomposition table; the documented SHALLOW normalization; ExportMode total-order lattice law; frozen/default invariants.

Full suite: **1050 passed, 1 skipped, 8 xfailed**; `lint-imports`: 4 contracts kept; `tools/check_docs.py` green.

## Relationship to #17

Independent — based on `main`, no shared files changed. #17 fixes today's legacy model (confidence-gated narrowing, capability-on-demand); this series replaces that model incrementally, and the transitional pieces of #17 are retired in later PRs of the series (narrowing gate dies with the legacy path; escalation approvers survive unchanged as authority mechanisms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjJ844CtPJFJcoMqanaobo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJ844CtPJFJcoMqanaobo)_