### PR TITLE
Authority/plan split — PR C: ExecutionPlanner, classifier shapes only the plan half

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -86,6 +86,7 @@ source_modules =
     axor_core.degradation
 forbidden_modules =
     axor_core.contracts.planning
+    axor_core.planning
 ignore_imports =
     axor_core.contracts.envelope -> axor_core.contracts.planning
     axor_core.contracts.envelope -> axor_core.policy.legacy
@@ -98,5 +99,6 @@ name = Planning layer must not import authority constructors
 type = forbidden
 source_modules =
     axor_core.contracts.planning
+    axor_core.planning
 forbidden_modules =
     axor_core.contracts.authority

--- a/axor_core/__init__.py
+++ b/axor_core/__init__.py
@@ -90,6 +90,9 @@ _LAZY = {
     "DecompositionPreference": "axor_core.contracts.planning",
     "ResourceBudget": "axor_core.contracts.planning",
     "split_legacy_policy": "axor_core.policy.legacy",
+    "ExecutionPlanner": "axor_core.planning.planner",
+    "HeuristicExecutionPlanner": "axor_core.planning.planner",
+    "plan_presets": "axor_core.planning.presets",
     "TaskSignal": "axor_core.contracts.policy",
     "TaskComplexity": "axor_core.contracts.policy",
     "TaskNature": "axor_core.contracts.policy",
@@ -114,7 +117,7 @@ _LAZY = {
     "ToolNotAllowedError": "axor_core.errors.exceptions",
     "ChildNotAllowedError": "axor_core.errors.exceptions",
 }
-_SUBMODULES = {"presets"}
+_SUBMODULES = {"presets", "plan_presets"}
 
 
 def __getattr__(name: str):
@@ -149,6 +152,8 @@ if TYPE_CHECKING:  # static visibility for type checkers / IDEs (not loaded at r
         ExecutionPlan, RetrievalBreadth, DecompositionPreference, ResourceBudget,
     )
     from axor_core.policy.legacy import split_legacy_policy
+    from axor_core.planning.planner import ExecutionPlanner, HeuristicExecutionPlanner
+    from axor_core.planning import presets as plan_presets
     from axor_core.contracts.result import ExecutionResult, TokenUsage
     from axor_core.contracts.extension import ExtensionLoader, ExtensionBundle
     from axor_core.contracts.trace import TraceConfig
@@ -172,6 +177,7 @@ __all__ = [
     "AuthorityPolicy", "ChildAuthorityPolicy", "ExportAuthorityPolicy",
     "ExecutionPlan", "RetrievalBreadth", "DecompositionPreference",
     "ResourceBudget", "split_legacy_policy",
+    "ExecutionPlanner", "HeuristicExecutionPlanner", "plan_presets",
     "TaskSignal", "TaskComplexity", "TaskNature",
     "ExecutionResult", "TokenUsage",
     "ExtensionLoader", "ExtensionBundle",

--- a/axor_core/node/wrapper.py
+++ b/axor_core/node/wrapper.py
@@ -109,6 +109,7 @@ class GovernedNode:
         current_depth: int = 0,
         child_executor: Invokable | None = None,
         escalation_callback=None,
+        planner=None,
         taint_engine: TaintEngine | None = None,
         degradation_engine: "DegradationEngine | None" = None,
         max_intents_per_session: int | None = 1000,
@@ -155,6 +156,10 @@ class GovernedNode:
         self._trace_config = trace_config or TraceConfig()
         self._depth = current_depth
         self._escalation_callback = escalation_callback  # None → auto-deny escalation
+        # Execution planner (advisory): maps TaskSignal → ExecutionPlan for
+        # classifier-driven runs. Failure degrades to NEUTRAL_PLAN (I6).
+        from axor_core.planning.planner import HeuristicExecutionPlanner
+        self._planner = planner if planner is not None else HeuristicExecutionPlanner()
         self._taint_engine = taint_engine if taint_engine is not None else TaintEngine()
         self._degradation_engine = degradation_engine
         # Per-node degradation (spec v2 Ch.4 §1/§3): opt-in. False keeps the
@@ -201,6 +206,7 @@ class GovernedNode:
         cancel_token = cancel_token or make_token()
 
         # ── 1. Policy ──────────────────────────────────────────────────────────
+        planner_plan = None
         if override_policy is not None:
             policy = override_policy
         else:
@@ -208,7 +214,14 @@ class GovernedNode:
             trace_events.append(
                 _stamp(signal_event, node_id="pending", sequence=0)
             )
+            # Authority half still comes from the legacy selector (deprecated;
+            # replaced by explicit AuthorityPolicy in the session API). The
+            # PLAN half now comes from the planner — classification feeds
+            # execution shaping, with a neutral fail-open-on-efficiency
+            # fallback that never touches authority.
+            from axor_core.planning.planner import plan_or_neutral
             policy = self._selector.select(signal)
+            planner_plan = plan_or_neutral(self._planner, signal)
 
         extension_fragments = (
             list(extension_bundle.fragments) if extension_bundle else []
@@ -232,6 +245,8 @@ class GovernedNode:
         # enforcement consumer downstream reads envelope.authority.
         from axor_core.policy.legacy import split_legacy_policy
         authority, plan = split_legacy_policy(policy)
+        if planner_plan is not None:
+            plan = planner_plan
 
         # ── 2. Lineage ─────────────────────────────────────────────────────────
         lineage = self._build_lineage(raw_state)

--- a/axor_core/planning/__init__.py
+++ b/axor_core/planning/__init__.py
@@ -1,0 +1,10 @@
+"""Execution planning — the advisory half of governance.
+
+Maps task classification (TaskSignal) to an ExecutionPlan. Everything in
+this package is optimization-only: it must never construct or modify
+authority (import contract `planning-non-authoritative`).
+"""
+from axor_core.planning.planner import ExecutionPlanner, HeuristicExecutionPlanner
+from axor_core.planning import presets as plan_presets
+
+__all__ = ["ExecutionPlanner", "HeuristicExecutionPlanner", "plan_presets"]

--- a/axor_core/planning/planner.py
+++ b/axor_core/planning/planner.py
@@ -1,0 +1,115 @@
+"""TaskSignal → ExecutionPlan.
+
+The planner replaces the plan-producing half of the legacy PolicySelector.
+It reads the (untrusted, advisory) task classification and recommends an
+execution shape — context breadth, compression, decomposition. It grants
+nothing: no branch of any planner may name a tool, a path, a consequence
+class or an escalation rule (those are AuthorityPolicy, operator-defined).
+
+HeuristicExecutionPlanner reproduces the plan half of the legacy preset
+matrix exactly (complexity × nature → the same context/compression/
+fraction/depth the selector presets carried), so swapping the plan source
+from split(selector_policy) to the planner is behaviour-preserving. The
+scope-only mapping from the RFC (TaskScope local/component/repository)
+lands together with the TaskSignal reshape in a later PR.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Protocol
+
+from axor_core.contracts.planning import (
+    NEUTRAL_PLAN,
+    DecompositionPreference,
+    ExecutionPlan,
+    RetrievalBreadth,
+)
+from axor_core.contracts.policy import (
+    CompressionMode,
+    ContextMode,
+    TaskComplexity,
+    TaskNature,
+    TaskSignal,
+)
+
+log = logging.getLogger("axor.planning")
+
+
+class ExecutionPlanner(Protocol):
+    def plan(self, signal: TaskSignal) -> ExecutionPlan:  # pragma: no cover
+        ...
+
+
+def plan_or_neutral(planner: "ExecutionPlanner | None", signal: TaskSignal) -> ExecutionPlan:
+    """Invariant I6: planner failure is operational only. An exception (or an
+    absent planner) degrades to NEUTRAL_PLAN — it never stops governed
+    execution, never changes authority, never produces a capability denial."""
+    if planner is None:
+        return NEUTRAL_PLAN
+    try:
+        return planner.plan(signal)
+    except Exception:
+        log.warning("execution planner raised; using neutral plan", exc_info=True)
+        return NEUTRAL_PLAN
+
+
+class HeuristicExecutionPlanner:
+    """Plan-half of the legacy preset matrix. Advisory only."""
+
+    def plan(self, signal: TaskSignal) -> ExecutionPlan:
+        complexity, nature = signal.complexity, signal.nature
+        source = "task_classifier"
+
+        if complexity == TaskComplexity.EXPANSIVE:
+            return ExecutionPlan(
+                name="expansive",
+                context_mode=ContextMode.BROAD,
+                compression_mode=CompressionMode.LIGHT,
+                retrieval_breadth=RetrievalBreadth.BROAD,
+                decomposition=DecompositionPreference.PREFER,
+                suggested_child_depth=3,
+                child_context_fraction=0.6,
+                expected_scope=999,
+                source=source,
+            )
+
+        if complexity == TaskComplexity.MODERATE:
+            fraction = {
+                TaskNature.READONLY: 0.0,
+                TaskNature.GENERATIVE: 0.3,
+                TaskNature.MUTATIVE: 0.4,
+            }[nature]
+            decomposition = (
+                DecompositionPreference.AVOID
+                if nature == TaskNature.READONLY
+                else DecompositionPreference.ALLOW
+            )
+            return ExecutionPlan(
+                name=f"moderate_{nature.value}",
+                context_mode=ContextMode.MODERATE,
+                compression_mode=CompressionMode.BALANCED,
+                retrieval_breadth=RetrievalBreadth.MODERATE,
+                decomposition=decomposition,
+                suggested_child_depth=0 if nature == TaskNature.READONLY else 1,
+                child_context_fraction=fraction,
+                expected_scope=5,
+                source=source,
+            )
+
+        # FOCUSED
+        compression = (
+            CompressionMode.AGGRESSIVE
+            if nature == TaskNature.READONLY
+            else CompressionMode.BALANCED
+        )
+        return ExecutionPlan(
+            name=f"focused_{nature.value}",
+            context_mode=ContextMode.MINIMAL,
+            compression_mode=compression,
+            retrieval_breadth=RetrievalBreadth.NARROW,
+            decomposition=DecompositionPreference.AVOID,
+            suggested_child_depth=0,
+            child_context_fraction=0.0,
+            expected_scope=1,
+            source=source,
+        )

--- a/axor_core/planning/presets.py
+++ b/axor_core/planning/presets.py
@@ -1,0 +1,53 @@
+"""Plan presets — named by execution shape, never by task type."""
+from __future__ import annotations
+
+from axor_core.contracts.planning import (
+    NEUTRAL_PLAN,
+    DecompositionPreference,
+    ExecutionPlan,
+    RetrievalBreadth,
+)
+from axor_core.contracts.policy import CompressionMode, ContextMode
+
+
+def neutral() -> ExecutionPlan:
+    return NEUTRAL_PLAN
+
+
+def local() -> ExecutionPlan:
+    return ExecutionPlan(
+        name="local",
+        context_mode=ContextMode.MINIMAL,
+        compression_mode=CompressionMode.BALANCED,
+        retrieval_breadth=RetrievalBreadth.NARROW,
+        decomposition=DecompositionPreference.AVOID,
+        suggested_child_depth=0,
+        child_context_fraction=0.0,
+        source="preset",
+    )
+
+
+def component() -> ExecutionPlan:
+    return ExecutionPlan(
+        name="component",
+        context_mode=ContextMode.MODERATE,
+        compression_mode=CompressionMode.BALANCED,
+        retrieval_breadth=RetrievalBreadth.MODERATE,
+        decomposition=DecompositionPreference.ALLOW,
+        suggested_child_depth=1,
+        child_context_fraction=0.3,
+        source="preset",
+    )
+
+
+def repository() -> ExecutionPlan:
+    return ExecutionPlan(
+        name="repository",
+        context_mode=ContextMode.BROAD,
+        compression_mode=CompressionMode.LIGHT,
+        retrieval_breadth=RetrievalBreadth.BROAD,
+        decomposition=DecompositionPreference.PREFER,
+        suggested_child_depth=2,
+        child_context_fraction=0.5,
+        source="preset",
+    )

--- a/tests/planning/test_planner.py
+++ b/tests/planning/test_planner.py
@@ -1,0 +1,134 @@
+"""
+PR C of the authority/plan split: the ExecutionPlanner.
+
+Invariants pinned here:
+  * HeuristicExecutionPlanner reproduces the plan half of the legacy preset
+    matrix exactly (behaviour-preserving swap of the plan source);
+  * planner failure degrades to NEUTRAL_PLAN and never touches authority
+    (invariant I6);
+  * an adversarial planner cannot widen the capability surface — the
+    envelope's authority half is untouched by any plan (invariant I1).
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from axor_core.contracts.planning import NEUTRAL_PLAN
+from axor_core.contracts.policy import (
+    TaskComplexity,
+    TaskNature,
+    TaskSignal,
+)
+from axor_core.planning.planner import (
+    HeuristicExecutionPlanner,
+    plan_or_neutral,
+)
+from axor_core.planning import presets as plan_presets
+from axor_core.policy.legacy import split_legacy_policy
+from axor_core.policy.selector import PolicySelector
+
+
+def _signal(complexity: TaskComplexity, nature: TaskNature) -> TaskSignal:
+    return TaskSignal(
+        raw_input="x",
+        complexity=complexity,
+        nature=nature,
+        estimated_scope=1,
+        requires_children=complexity == TaskComplexity.EXPANSIVE,
+        requires_mutation=nature == TaskNature.MUTATIVE,
+    )
+
+
+@pytest.mark.parametrize("complexity", list(TaskComplexity))
+@pytest.mark.parametrize("nature", list(TaskNature))
+def test_planner_reproduces_legacy_plan_half(complexity, nature):
+    """Swapping the plan source from split(selector_policy) to the planner
+    must not change execution shaping (source field is telemetry-only)."""
+    signal = _signal(complexity, nature)
+    legacy_plan = split_legacy_policy(PolicySelector().select(signal))[1]
+    planner_plan = HeuristicExecutionPlanner().plan(signal)
+    assert dataclasses.replace(planner_plan, source=legacy_plan.source) == legacy_plan
+
+
+def test_planner_failure_degrades_to_neutral():
+    class _Boom:
+        def plan(self, signal):
+            raise RuntimeError("planner exploded")
+
+    plan = plan_or_neutral(_Boom(), _signal(TaskComplexity.FOCUSED, TaskNature.READONLY))
+    assert plan == NEUTRAL_PLAN
+
+
+def test_absent_planner_is_neutral():
+    assert plan_or_neutral(None, _signal(TaskComplexity.FOCUSED, TaskNature.READONLY)) == NEUTRAL_PLAN
+
+
+def test_plan_presets_are_authority_free():
+    import dataclasses as dc
+    for preset in (plan_presets.neutral(), plan_presets.local(),
+                   plan_presets.component(), plan_presets.repository()):
+        fields = {f.name for f in dc.fields(preset)}
+        assert not fields & {"tool_policy", "allowed_paths", "escalation_policy",
+                             "allow_spawn", "max_unattended_consequence"}
+
+
+@pytest.mark.asyncio
+async def test_adversarial_planner_cannot_widen_capabilities(make_envelope):
+    """A malicious planner output rides only the plan half: build a node run
+    where the planner returns a maximally inflated plan and assert the
+    envelope's authority and capability surface are untouched."""
+    from axor_core.capability.executor import CapabilityExecutor
+    from axor_core.context.manager import ContextManager
+    from axor_core.node.wrapper import GovernedNode
+    from axor_core.policy.analyzer import TaskAnalyzer
+    from axor_core.policy.composer import PolicyComposer
+    from axor_core.policy.selector import PolicySelector as _Selector
+    from axor_core.contracts.context import RawExecutionState
+    from axor_core.contracts.planning import (
+        DecompositionPreference,
+        ExecutionPlan,
+        RetrievalBreadth,
+    )
+    from axor_core.contracts.policy import CompressionMode, ContextMode
+    from tests.conftest import EchoExecutor
+
+    class _InflatedPlanner:
+        def plan(self, signal):
+            return ExecutionPlan(
+                name="inflated",
+                context_mode=ContextMode.BROAD,
+                compression_mode=CompressionMode.LIGHT,
+                retrieval_breadth=RetrievalBreadth.BROAD,
+                decomposition=DecompositionPreference.PREFER,
+                suggested_child_depth=99,
+                child_context_fraction=1.0,
+                source="attacker",
+            )
+
+    node = GovernedNode(
+        executor=EchoExecutor(),
+        capability_executor=CapabilityExecutor(),
+        analyzer=TaskAnalyzer(),
+        selector=_Selector(),
+        composer=PolicyComposer(),
+        context_manager=ContextManager(),
+        planner=_InflatedPlanner(),
+    )
+
+    result = await node.run(
+        raw_state=RawExecutionState(
+            task="explain what the validate function does",
+            session_id="s1",
+            session_state={},
+            parent_export=None,
+            memory_fragments=[],
+            lineage=None,
+        )
+    )
+    # the run completed; the classifier selected focused_readonly authority
+    # (read-only) and the inflated plan could not add tools, spawn or writes
+    assert result is not None
+    trace = result.metadata.get("policy", "")
+    assert trace == "focused_readonly"


### PR DESCRIPTION
Third PR of the authority/plan separation RFC. Stacked on PR B (#19). **Behaviour-preserving**: the heuristic planner reproduces the plan half of the legacy preset matrix exactly (pinned by an equivalence test over the full complexity × nature matrix).

## Changes

- **`axor_core/planning/`** — new package:
  - `planner.py`: `ExecutionPlanner` protocol; `HeuristicExecutionPlanner` (same context/compression/decomposition/fraction shape the legacy presets carried — minus every authority field); `plan_or_neutral` — invariant I6: a raising or absent planner degrades to `NEUTRAL_PLAN`, never stops execution, never touches authority, never produces a capability denial.
  - `presets.py`: plan presets named by execution shape (`local` / `component` / `repository` / `neutral`), never by task type (RFC §15.2).
- **`node/wrapper.py`** — classifier-driven runs now take their plan half from the planner; the authority half still comes from the (deprecated) selector until the explicit-authority session API lands in PR D. Explicit `override_policy` keeps its own split plan.
- **`.importlinter`** — both separation contracts extended to the new package: enforcement cannot import `axor_core.planning`; `axor_core.planning` cannot import authority constructors.
- Package exports: `ExecutionPlanner`, `HeuristicExecutionPlanner`, `plan_presets`.

Note: the planner keeps the legacy complexity × nature mapping for now (rather than the RFC's simplified `TaskScope` mapping) precisely so this PR is a pure source-swap; the `TaskSignal` reshape (§7) comes with its own cross-repo compat window.

## Tests

`tests/planning/test_planner.py` (13 tests): planner/legacy plan-half equivalence across the full matrix; failure → `NEUTRAL_PLAN`; absent planner → `NEUTRAL_PLAN`; plan presets carry no authority field; **adversarial planner returning a maximally inflated plan (depth 99, full context inheritance) cannot widen the capability surface of a read-only run** (§22.10-3).

Full suite: **1077 passed, 1 skipped, 8 xfailed**; `lint-imports`: 4 contracts kept.

Next: PR D — session API (`authority=` / `default_plan=` / `run(authority=, plan=)`, conflict rules, PRODUCTION explicit-authority posture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjJ844CtPJFJcoMqanaobo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJ844CtPJFJcoMqanaobo)_