### PR TITLE
Authority/plan split — PR E: dynamic replanning within ResourceBudget

### DIFF
--- a/axor_core/contracts/trace.py
+++ b/axor_core/contracts/trace.py
@@ -19,6 +19,8 @@ class TraceEventKind(str, Enum):
     SIGNAL_CHOSEN = "signal_chosen"
     POLICY_CHOSEN = "policy_chosen"
     POLICY_ADJUSTED = "policy_adjusted"
+    EXECUTION_PLAN_CHANGED = "execution_plan_changed"
+    PLAN_CONSTRAINED_BY_BUDGET = "plan_constrained_by_budget"
 
     # intents
     INTENT_APPROVED = "intent_approved"

--- a/axor_core/node/intent_loop.py
+++ b/axor_core/node/intent_loop.py
@@ -156,6 +156,7 @@ class IntentLoop:
         trajectory_observers: "list | None" = None,
         invocation_recorder: "Callable[[str, dict, bool], None] | None" = None,
         admission: "AdmissionController | None" = None,
+        resource_budget=None,
     ) -> None:
         self._executor = capability_executor
         self._trace_events = trace_events
@@ -274,6 +275,14 @@ class IntentLoop:
                 "definition; they must stay on the content-derivation path."
             )
         self._spawn_count = 0
+        # Dynamic replanning (advisory): plan expansions are bounded by the
+        # operator's ResourceBudget, never by authority — widening a plan
+        # changes what the run may SPEND, not what it may EFFECT.
+        if resource_budget is None:
+            from axor_core.contracts.planning import ResourceBudget
+            resource_budget = ResourceBudget()
+        self._resource_budget = resource_budget
+        self._plan_expansions = 0
 
     async def run(
         self,
@@ -354,6 +363,24 @@ class IntentLoop:
                                     "tool_result": result,
                                     "approved": True,
                                 },
+                                node_id=envelope.node_id,
+                            )
+                        continue
+
+                    # request_plan_expansion — advisory replanning intent.
+                    # Handled BEFORE the gate cascade (like escalate_policy):
+                    # it is not a tool call and grants nothing — it adjusts
+                    # the envelope's plan within the ResourceBudget.
+                    if tool_name == "request_plan_expansion":
+                        result = self._handle_plan_expansion(event, envelope)
+                        if self._tool_result_callback is not None:
+                            await self._tool_result_callback(
+                                tool_use_id, tool_name, result, True
+                            )
+                        else:
+                            yield ExecutorEvent(
+                                kind=ExecutorEventKind.TEXT,
+                                payload={"tool_result": result, "approved": True},
                                 node_id=envelope.node_id,
                             )
                         continue
@@ -991,6 +1018,75 @@ class IntentLoop:
             kind=PolicyDecisionKind.DENY,
             reason=f"tool '{tool_name}' is not in capabilities for policy '{envelope.authority.name}'",
         ), pending
+
+    def _handle_plan_expansion(self, event: ExecutorEvent, envelope) -> dict:
+        """Adjust envelope.plan within the ResourceBudget (RFC §13).
+
+        Distinct from escalate_policy by design: "need more context" is a
+        budget question, "need another tool" is an authority question. The
+        new plan affects subsequent planning consumers (child context
+        shaping, budget decisions); it never touches envelope.authority or
+        capabilities."""
+        from axor_core.planning.composer import PlanComposer
+
+        args = event.payload.get("args", {}) or {}
+        reason = str(args.get("reason", ""))
+        budget = self._resource_budget
+
+        if (
+            budget.max_plan_expansions is not None
+            and self._plan_expansions >= budget.max_plan_expansions
+        ):
+            self._trace_events.append(TraceEvent(
+                kind=TraceEventKind.PLAN_CONSTRAINED_BY_BUDGET,
+                node_id=envelope.node_id,
+                sequence=len(self._trace_events),
+                payload={"constraints": ["max_plan_expansions reached"],
+                         "reason": reason},
+            ))
+            return {
+                "granted": False,
+                "reason": f"plan expansion budget exhausted "
+                          f"({budget.max_plan_expansions})",
+            }
+
+        new_plan, constraints = PlanComposer().expand(
+            envelope.plan,
+            budget,
+            requested_context_mode=args.get("requested_context_mode"),
+            requested_child_depth=args.get("requested_child_depth"),
+            additional_token_reservation=args.get("additional_token_reservation"),
+            reason=reason,
+        )
+        if constraints:
+            self._trace_events.append(TraceEvent(
+                kind=TraceEventKind.PLAN_CONSTRAINED_BY_BUDGET,
+                node_id=envelope.node_id,
+                sequence=len(self._trace_events),
+                payload={"constraints": constraints, "reason": reason},
+            ))
+        if new_plan is not envelope.plan:
+            envelope.plan = new_plan
+            self._plan_expansions += 1
+            self._trace_events.append(TraceEvent(
+                kind=TraceEventKind.EXECUTION_PLAN_CHANGED,
+                node_id=envelope.node_id,
+                sequence=len(self._trace_events),
+                payload={
+                    "plan_name": new_plan.name,
+                    "context_mode": new_plan.context_mode.value,
+                    "suggested_child_depth": new_plan.suggested_child_depth,
+                    "token_reservation": new_plan.token_reservation,
+                    "reason": reason,
+                    "source": new_plan.source,
+                },
+            ))
+        return {
+            "granted": True,
+            "plan": new_plan.name,
+            "context_mode": new_plan.context_mode.value,
+            "constrained": constraints,
+        }
 
     async def _handle_escalation(
         self,

--- a/axor_core/planning/composer.py
+++ b/axor_core/planning/composer.py
@@ -1,0 +1,87 @@
+"""PlanComposer — merge/expand ExecutionPlans within a ResourceBudget.
+
+Unlike authority composition, plan composition is NOT monotonic: a plan may
+widen (more context, less compression, deeper decomposition hint) as well as
+narrow — but only inside the operator's ResourceBudget ceilings. Widening a
+plan is not a capability escalation: it changes what the run may spend,
+never what it may effect.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+from axor_core.contracts.planning import ExecutionPlan, ResourceBudget
+from axor_core.contracts.policy import ContextMode
+
+_CONTEXT_ORDER = [ContextMode.MINIMAL, ContextMode.MODERATE, ContextMode.BROAD]
+
+
+class PlanComposer:
+    """Budget-bounded plan adjustment."""
+
+    def expand(
+        self,
+        base: ExecutionPlan,
+        budget: ResourceBudget,
+        *,
+        requested_context_mode: str | None = None,
+        requested_child_depth: int | None = None,
+        additional_token_reservation: int | None = None,
+        reason: str = "",
+    ) -> tuple[ExecutionPlan, list[str]]:
+        """Apply a requested expansion, clamped to the budget.
+
+        Returns (new_plan, constraints) — `constraints` lists every requested
+        widening the budget refused (telemetry: PLAN_CONSTRAINED_BY_BUDGET).
+        Malformed or negative requests are ignored fail-closed: they can
+        never shrink a ceiling or smuggle non-planning fields.
+        """
+        changes: dict = {}
+        constraints: list[str] = []
+
+        if requested_context_mode is not None:
+            try:
+                mode = ContextMode(requested_context_mode)
+            except ValueError:
+                constraints.append(f"unknown context_mode {requested_context_mode!r}")
+            else:
+                changes["context_mode"] = mode
+
+        if requested_child_depth is not None:
+            try:
+                depth = int(requested_child_depth)
+            except (TypeError, ValueError):
+                depth = -1
+            if depth < 0:
+                constraints.append("child_depth must be a non-negative integer")
+            else:
+                if budget.max_children is not None and depth > budget.max_children:
+                    constraints.append(
+                        f"child_depth {depth} > budget.max_children {budget.max_children}"
+                    )
+                    depth = budget.max_children
+                changes["suggested_child_depth"] = depth
+
+        if additional_token_reservation is not None:
+            try:
+                extra = int(additional_token_reservation)
+            except (TypeError, ValueError):
+                extra = -1
+            if extra < 0:
+                constraints.append("token reservation must be a non-negative integer")
+            else:
+                total = (base.token_reservation or 0) + extra
+                cap = budget.max_token_reservation
+                if cap is not None and total > cap:
+                    constraints.append(
+                        f"token_reservation {total} > budget cap {cap}"
+                    )
+                    total = cap
+                changes["token_reservation"] = total
+
+        if not changes:
+            return base, constraints
+        new_plan = dataclasses.replace(
+            base, **changes, source="plan_expansion", name=base.name,
+        )
+        return new_plan, constraints

--- a/axor_core/trace/collector.py
+++ b/axor_core/trace/collector.py
@@ -451,6 +451,11 @@ _KIND_ALLOWED_PAYLOAD: dict[TraceEventKind, set[str]] = {
         "before_tokens", "after_tokens", "compression_ratio",
     },
     TraceEventKind.EXTENSION_LOADED: {"name", "kind", "source"},
+    TraceEventKind.EXECUTION_PLAN_CHANGED: {
+        "plan_name", "context_mode", "suggested_child_depth",
+        "token_reservation", "reason", "source",
+    },
+    TraceEventKind.PLAN_CONSTRAINED_BY_BUDGET: {"constraints", "reason"},
 }
 
 # TaskSignal fields safe to persist. raw_input is gated by persist_inputs.

--- a/tests/planning/test_plan_expansion.py
+++ b/tests/planning/test_plan_expansion.py
@@ -1,0 +1,117 @@
+"""
+PR E of the authority/plan split: dynamic replanning within ResourceBudget.
+
+Invariants pinned here:
+  * a plan expansion changes envelope.plan, never envelope.authority or
+    capabilities (widening a plan is not a capability escalation);
+  * ResourceBudget ceilings clamp and are trace-visible;
+  * malformed/negative requests fail closed (ignored, never crash);
+  * the expansion counter enforces max_plan_expansions.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from axor_core.capability.executor import CapabilityExecutor
+from axor_core.contracts.planning import ExecutionPlan, ResourceBudget
+from axor_core.contracts.policy import ContextMode
+from axor_core.contracts.result import ExecutorEvent, ExecutorEventKind
+from axor_core.contracts.trace import TraceEventKind
+from axor_core.node.intent_loop import IntentLoop
+from axor_core.planning.composer import PlanComposer
+
+
+def _loop(budget=None, trace=None):
+    return IntentLoop(
+        capability_executor=CapabilityExecutor(),
+        trace_events=trace if trace is not None else [],
+        resource_budget=budget or ResourceBudget(),
+    )
+
+
+def _expansion_event(**args) -> ExecutorEvent:
+    return ExecutorEvent(
+        kind=ExecutorEventKind.TOOL_USE,
+        payload={"tool": "request_plan_expansion", "tool_use_id": "pe-1",
+                 "args": {"reason": "need more context", **args}},
+        node_id="n1",
+    )
+
+
+def test_expansion_changes_plan_not_authority(make_envelope):
+    env = make_envelope()
+    authority_before = env.authority
+    caps_before = env.capabilities
+    trace: list = []
+    loop = _loop(trace=trace)
+
+    result = loop._handle_plan_expansion(
+        _expansion_event(requested_context_mode="broad"), env
+    )
+    assert result["granted"] is True
+    assert env.plan.context_mode == ContextMode.BROAD
+    assert env.plan.source == "plan_expansion"
+    assert env.authority == authority_before
+    assert env.capabilities == caps_before
+    kinds = [e.kind for e in trace]
+    assert TraceEventKind.EXECUTION_PLAN_CHANGED in kinds
+
+
+def test_budget_clamps_reservation_and_reports_constraint(make_envelope):
+    env = make_envelope()
+    trace: list = []
+    loop = _loop(budget=ResourceBudget(max_token_reservation=1000), trace=trace)
+
+    result = loop._handle_plan_expansion(
+        _expansion_event(additional_token_reservation=5000), env
+    )
+    assert result["granted"] is True
+    assert env.plan.token_reservation == 1000
+    assert any(
+        e.kind == TraceEventKind.PLAN_CONSTRAINED_BY_BUDGET for e in trace
+    )
+
+
+def test_max_plan_expansions_enforced(make_envelope):
+    env = make_envelope()
+    loop = _loop(budget=ResourceBudget(max_plan_expansions=1))
+
+    first = loop._handle_plan_expansion(
+        _expansion_event(requested_context_mode="broad"), env
+    )
+    assert first["granted"] is True
+    second = loop._handle_plan_expansion(
+        _expansion_event(requested_context_mode="minimal"), env
+    )
+    assert second["granted"] is False
+    assert "exhausted" in second["reason"]
+
+
+@pytest.mark.parametrize("bad_args", [
+    {"requested_child_depth": -5},
+    {"requested_child_depth": "lots"},
+    {"additional_token_reservation": -1},
+    {"requested_context_mode": "omniscient"},
+])
+def test_malformed_requests_fail_closed(make_envelope, bad_args):
+    env = make_envelope()
+    plan_before = env.plan
+    loop = _loop()
+    result = loop._handle_plan_expansion(_expansion_event(**bad_args), env)
+    assert result["granted"] is True          # advisory: nothing to grant
+    assert env.plan == plan_before            # but nothing changed either
+
+
+def test_composer_cannot_smuggle_authority_fields():
+    """The expansion surface only ever touches planning fields."""
+    plan = ExecutionPlan()
+    new_plan, _ = PlanComposer().expand(
+        plan, ResourceBudget(), requested_context_mode="broad",
+    )
+    changed = {
+        f.name for f in dataclasses.fields(ExecutionPlan)
+        if getattr(new_plan, f.name) != getattr(plan, f.name)
+    }
+    assert changed <= {"context_mode", "source", "name"}


### PR DESCRIPTION
Fifth PR of the authority/plan separation RFC. Stacked on PR D (#21).

Initial task classification may misjudge scope; recovering from that must not require capability escalation (RFC §13) — *"need more context" is a budget question, "need another tool" stays an authority question* (§16.3).

## Changes

- **`planning/composer.py`** — `PlanComposer.expand`: budget-bounded plan adjustment. Plan composition is deliberately **not monotonic** (§12.2): a plan may widen as well as narrow, but only inside `ResourceBudget` ceilings. Malformed/negative requests are ignored fail-closed and reported as constraints.
- **`node/intent_loop.py`** — `request_plan_expansion` intent, dispatched **before** the gate cascade (like `escalate_policy` — it is not a tool call and grants nothing, so it also bypasses the STRICT role-completeness check by construction). Adjusts `envelope.plan` in place; bounded by `max_plan_expansions`; never touches `envelope.authority` or capabilities. `IntentLoop` gains a `resource_budget` parameter (default: unlimited).
- **Trace** — `EXECUTION_PLAN_CHANGED` and `PLAN_CONSTRAINED_BY_BUDGET` event kinds with fail-closed collector payload whitelist entries (§17).

Deferred from §17: predicted-vs-actual analytics (§17.4) — lands with the docs/deprecation PR F as a telemetry follow-up note; it needs no core hooks beyond the events added here.

## Tests

`tests/planning/test_plan_expansion.py` (8 tests): expansion changes plan, never authority/capabilities; budget clamps reservation and reports the constraint in trace; `max_plan_expansions` enforced; malformed requests (negative depth, junk mode, negative reservation — §22.10-7/8) fail closed; the expansion surface can only touch planning fields.

Full suite: **1094 passed, 1 skipped, 8 xfailed**; `lint-imports`: 4 contracts kept.

Next: PR F — docs and deprecation (README, ARCHITECTURE, governance model, threat model, migration guide, CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjJ844CtPJFJcoMqanaobo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJ844CtPJFJcoMqanaobo)_