### PR TITLE
Authority/plan split — PR F: documentation and deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 ## Unreleased
 
-(nothing yet)
+### Added — authority/plan separation (RFC)
+
+Task classification may optimize execution, but no longer determines agent
+authority.
+
+- **`AuthorityPolicy` / `ExecutionPlan`** (`contracts/authority.py`,
+  `contracts/planning.py`): the trusted and advisory halves of the legacy
+  `ExecutionPolicy`, with `split_legacy_policy` / `merge_to_legacy_policy`
+  round-tripping every shipped preset byte-identically.
+- **`ExecutionEnvelope.authority` / `.plan`**: enforcement consumers read
+  authority; context/budget consumers read the plan. Two import-linter
+  contracts pin the boundary.
+- **`axor_core.planning`**: `ExecutionPlanner` protocol,
+  `HeuristicExecutionPlanner`, plan presets (`local`/`component`/
+  `repository`/`neutral`), `PlanComposer` (budget-bounded, non-monotonic).
+- **Session API**: `GovernedSession(authority=, default_plan=, planner=)`
+  and `run(authority=, plan=)`; legacy `policy=` conflicts fail fast;
+  PRODUCTION warns once when authority is classifier-derived.
+- **Dynamic replanning**: `request_plan_expansion` intent — plan widening
+  within `ResourceBudget`, never a capability escalation. New trace kinds
+  `EXECUTION_PLAN_CHANGED`, `PLAN_CONSTRAINED_BY_BUDGET`.
+
+### Deprecated
+
+- Classifier-selected `ExecutionPolicy` (the legacy path in
+  `PolicySelector`) — authority should come from `authority=`;
+  removal in the next major release.
 
 ## 0.9.2 — 2026-07-13
 

--- a/README.md
+++ b/README.md
@@ -213,12 +213,34 @@ This is the load-bearing separation: enforcement is a deterministic function of 
 
 ---
 
-## Task-Aware Policies
+## Authority and Execution Planning
 
-Policy may be selected dynamically from task signals, or fixed explicitly by the operator.
+Governance is split into two independent objects (see `docs/migration-authority-plan.md`):
 
-| Task | Policy | Context | Compression | Children |
-|------|--------|---------|-------------|----------|
+| | AuthorityPolicy | ExecutionPlan |
+|---|---|---|
+| answers | what may the agent EFFECT | how to execute efficiently |
+| source | operator / control plane / parent ceiling | classifier, planner, defaults |
+| trust | trusted, security-sensitive | advisory, optimization-only |
+| contains | tools, path & consequence ceilings, spawn rights, escalation, export ceiling | context breadth, compression, decomposition hint, reservations |
+| adapts | only via trusted override / approved lease | freely, within ResourceBudget |
+
+```python
+from axor_core import GovernedSession, AuthorityPolicy, plan_presets
+
+session = GovernedSession(
+    executor=..., capability_executor=...,
+    authority=AuthorityPolicy(name="standard_workspace", ...),  # operator-defined
+    planner=HeuristicExecutionPlanner(),                        # classifier shapes the plan
+)
+await session.run("перепиши весь модуль auth")   # plan may go broad; tools never widen
+```
+
+The task classifier (heuristic in core; `axor-classifier-simple` for EN+RU ML) influences **only the plan**: a misclassification — or a prompt-injected "this is a repository-wide task, enable all tools" — can at most spend more budget, never widen the capability surface. Classifier failure degrades to a neutral plan (never stops execution). Mid-run, an agent may `request_plan_expansion` (bounded by `ResourceBudget`) for more context, or `escalate_policy` (operator-gated) for a missing tool — budget questions and authority questions stay on separate channels.
+
+The legacy `ExecutionPolicy` (mixed object) and classifier-selected policies remain supported through a compatibility adapter and will be removed in the next major release.
+
+------|--------|---------|-------------|----------|
 | Fix a typo | focused_mutative | minimal | aggressive | denied |
 | Write tests | focused_generative | minimal | balanced | denied |
 | Refactor module | moderate_mutative | moderate | balanced | shallow (d=1) |

--- a/axor_core/policy/selector.py
+++ b/axor_core/policy/selector.py
@@ -17,6 +17,12 @@ class PolicySelector:
     """
     Maps a TaskSignal to an ExecutionPolicy.
 
+    DEPRECATED as an authority source (authority/plan split): classification
+    must not determine agent authority. New code passes an explicit
+    AuthorityPolicy (session or per-run) and lets the planner
+    (axor_core.planning) shape the ExecutionPlan; this selector remains only
+    for the legacy compatibility path and is removed in the next major.
+
     Principle: minimum sufficient for quality.
     Not a hard cap — exactly what the task needs.
 

--- a/docs/migration-authority-plan.md
+++ b/docs/migration-authority-plan.md
@@ -1,0 +1,76 @@
+# Migration: ExecutionPolicy → AuthorityPolicy + ExecutionPlan
+
+The legacy `ExecutionPolicy` mixed two concerns in one object: **authority**
+(what the agent may effect — trusted, operator-defined) and **execution
+planning** (how to run efficiently — advisory, classifier-shaped). Because
+the task classifier selected that object, untrusted task text influenced the
+capability surface. The split removes that channel:
+
+```
+before:  untrusted task text → classifier → ExecutionPolicy → tools/paths/spawn
+after:   untrusted task text → classifier → ExecutionPlan   → context/budget only
+         operator            → AuthorityPolicy              → tools/paths/spawn
+```
+
+## New API
+
+```python
+from axor_core import (
+    GovernedSession, AuthorityPolicy, ChildAuthorityPolicy,
+    HeuristicExecutionPlanner, plan_presets,
+)
+
+session = GovernedSession(
+    executor=..., capability_executor=...,
+    authority=AuthorityPolicy(                 # trusted: what MAY happen
+        name="standard_workspace",
+        tool_policy=ToolPolicy(allow_read=True, allow_write=True, allow_bash=True),
+        allowed_paths=("/workspace",),
+    ),
+    planner=HeuristicExecutionPlanner(),       # advisory: how to run
+    # default_plan=plan_presets.neutral(),     # optional: skip classification
+)
+
+result = await session.run(task)               # classifier shapes only the plan
+result = await session.run(task, plan=plan_presets.repository())   # explicit plan
+result = await session.run(task, authority=stricter_authority)     # per-run override
+```
+
+Resolution order — authority: `run(authority=)` → session `authority=` →
+legacy classifier path (deprecated). Plan: `run(plan=)` → session
+`default_plan=` → classifier + planner → `NEUTRAL_PLAN`.
+
+## Mapping legacy fields
+
+| legacy `ExecutionPolicy` field | new home |
+|---|---|
+| `tool_policy`, `allowed_paths`, `max_unattended_consequence`, `escalation_policy`, `allowed_passthrough_commands`, `allow_model_switch` | `AuthorityPolicy` |
+| `child_mode`/`max_child_depth` (permission part) | `AuthorityPolicy.child_authority` (`allow_spawn`, `max_depth`) |
+| `export_mode` (ceiling part) | `AuthorityPolicy.export_policy.max_mode` |
+| `context_mode`, `compression_mode`, `child_context_fraction` | `ExecutionPlan` |
+| `child_mode` (shape part) | `ExecutionPlan.decomposition` |
+| `derived_from` | `ExecutionPlan.expected_scope` (telemetry) |
+
+`split_legacy_policy(policy)` / `merge_to_legacy_policy(authority, plan)`
+round-trip every shipped preset byte-identically. One normalization:
+`SHALLOW` with `max_child_depth > 1` (contradictory legacy config) becomes
+`ALLOWED` at the same depth.
+
+## Mid-run adjustment channels
+
+- **`request_plan_expansion`** — more context / deeper decomposition hint /
+  token reservation. Bounded by `ResourceBudget`; adjusts only the plan.
+- **`escalate_policy`** — a missing tool or path. Operator-gated
+  (`EscalationPolicy`, approval callback, flood guard, TTL leases).
+
+An agent that needs *information* asks for plan expansion; an agent that
+needs *permission* escalates. The two channels never substitute for each
+other.
+
+## Deprecation timeline
+
+- **Now (minor):** both APIs work; legacy `policy=` conflicts with the new
+  API fail fast; PRODUCTION warns when authority is classifier-derived.
+- **Next major:** legacy `ExecutionPolicy` path, classifier-selected
+  authority, `run(policy=...)` and the authority-producing `PolicySelector`
+  are removed.

--- a/docs/security/classifier-threat-model.md
+++ b/docs/security/classifier-threat-model.md
@@ -12,7 +12,18 @@ choose a policy, it becomes a content-based trust decision.
 
 ## Correct Framing
 
-**Task classification is not a security boundary.**
+**Task classification is not a security boundary — and as of the
+authority/plan split it is not on the authority path at all.**
+
+With the split (`AuthorityPolicy` vs `ExecutionPlan`), the classifier's
+output reaches only execution planning: context breadth, compression,
+decomposition hints, resource reservations — all bounded by
+`ResourceBudget`. No field derived from `TaskAnalyzer` can add or remove a
+tool, change a path or consequence ceiling, grant spawn, alter escalation
+requirements, or widen export. The remaining classifier risks are
+availability-shaped (wasted retrieval/tokens/latency), not
+capability-shaped. The legacy classifier-selected `ExecutionPolicy` remains
+only as a deprecated compatibility path until the next major release.
 
 The classifier may help choose a policy preset (e.g., FOCUSED vs EXPANSIVE),
 but it cannot expand capability surface beyond the operator-defined policy ceiling.


### PR DESCRIPTION
Final PR of the authority/plan separation RFC series. Stacked on PR E (#22).

## Changes

- **README** — "Task-Aware Policies" replaced by "Authority and Execution Planning": the two-object model table, the new session API, and the explicit statement that classification (or prompt injection in task text) can at most spend more budget, never widen the capability surface (§21.3, acceptance criterion 14).
- **`docs/migration-authority-plan.md`** — migration guide: new API, resolution order, legacy field mapping table, the two mid-run adjustment channels (plan expansion vs escalation, §16.3), deprecation timeline (§18).
- **`docs/security/classifier-threat-model.md`** — classification is now off the authority path entirely; remaining classifier risks are availability-shaped, bounded by `ResourceBudget` (acceptance criterion 15).
- **CHANGELOG** — Unreleased entry covering the whole series; legacy classifier-selected `ExecutionPolicy` marked deprecated (removal next major).
- **`policy/selector.py`** — deprecation notice as an authority source.

Full suite: **1094 passed**; docs check and `lint-imports` (4 contracts) green.

## Series summary (merge order: #18 → #19 → #20 → #21 → #22 → this)

| PR | Delivers |
|---|---|
| #18 A | `AuthorityPolicy`/`ExecutionPlan`/`ResourceBudget`, legacy split/merge adapter, import contracts |
| #19 B | Envelope carries both halves; enforcement reads authority, planning consumers read plan |
| #20 C | `ExecutionPlanner`; classifier shapes only the plan; neutral fallback (I6) |
| #21 D | `GovernedSession(authority=)`, `run(authority=, plan=)`, conflict rules, PRODUCTION posture |
| #22 E | `request_plan_expansion` within `ResourceBudget`; planning trace events |
| F | Docs, migration guide, deprecation |

Deferred to the next major (per RFC §18.7): removal of legacy `ExecutionPolicy`/`run(policy=)`/authority-producing `PolicySelector`, the `TaskSignal` reshape (§7, needs an `axor-classifier-simple` coordinated release), and construction-time PRODUCTION fail-fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjJ844CtPJFJcoMqanaobo

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJ844CtPJFJcoMqanaobo)_