### PR TITLE
Kernel: record and name the provenance a verdict was reached on

### DIFF
--- a/axor_core/governor.py
+++ b/axor_core/governor.py
@@ -49,6 +49,49 @@ from axor_core.kernel.registration import (
 )
 from axor_core.taint.engine import TaintEngine
 
+# The closed set of denial categories, and the GATE each one names.
+#
+# Categories are an internal vocabulary; the gate names are the kernel's own
+# nine-gate sequence, and they are what a recorded trace has to carry — a
+# consumer asking "which gate denied this?" should not have to reverse-engineer
+# it from a category string. Exporting the mapping is what stops every consumer
+# from keeping a private copy: axor-lab kept one whose keys were `ssrf`,
+# `consequence`, `positional`, `carrier` — names this kernel does not emit (it
+# emits `ssrf_gate`, `consequence_gate`, …) — so seven of eleven categories fell
+# through unmapped and produced traces that failed schema validation.
+#
+# Adding a category without adding it here fails `test_gate_vocabulary.py`.
+GATE_OF_CATEGORY: dict[str, str] = {
+    "taint_enforcement": "taint_floor",
+    "consequence_gate": "consequence",
+    "value_policy": "value_policies",
+    "ssrf_gate": "ssrf",
+    "positional_gate": "positional",
+    "carrier_gate": "carrier",
+    "message_gate": "message",
+    "budget": "budget",
+    "degradation": "degradation",
+    "capability": "capability",
+    # an unclassified tool is refused by the capability gate: it has no declared
+    # role, so no capability to act under.
+    "unclassified_tool": "capability",
+}
+
+DENIAL_CATEGORIES: frozenset[str] = frozenset(GATE_OF_CATEGORY)
+
+
+def gate_of(category: str) -> str:
+    """The gate a denial category names. Unknown categories raise rather than
+    passing the raw category through — a category leaking into a field that
+    expects a gate name is how an unrecognised denial became an invalid trace
+    instead of a loud error."""
+    try:
+        return GATE_OF_CATEGORY[category]
+    except KeyError:
+        raise ValueError(
+            f"unknown denial category {category!r}; known: {sorted(DENIAL_CATEGORIES)}"
+        ) from None
+
 
 @dataclass
 class GovernanceDecision:
@@ -203,22 +246,28 @@ class ToolCallGovernor:
         )
         normalized = self._normalizer.normalize(intent)
 
-        def _deny(gd: GateDecision) -> GovernanceDecision:
+        def _denied(reason: str, category: str) -> GovernanceDecision:
+            """EVERY denial goes through here. A denial that returns directly is
+            a verdict with no trace: replay sees an intent with no decision, and
+            a consumer never learns the kernel blocked anything."""
             self._trace_events.append(
                 IntentDeniedEvent(
                     kind=TraceEventKind.INTENT_DENIED,
                     node_id=self._node_id,
                     sequence=len(self._trace_events),
                     intent_kind=IntentKind.TOOL_CALL.value,
-                    reason=gd.reason,
+                    reason=reason,
                     payload={**self._call_payload(tool_name, args),
-                             "category": gd.category},
+                             "category": category},
                 )
             )
             return GovernanceDecision(
-                allowed=False, reason=gd.reason, category=gd.category,
+                allowed=False, reason=reason, category=category,
                 _normalized=normalized,
             )
+
+        def _deny(gd: GateDecision) -> GovernanceDecision:
+            return _denied(gd.reason, gd.category)
 
         # 0. STRICT role completeness (lazy): an unclassified tool fails closed
         #    rather than defaulting to a clean benign read. This is the fix for the
@@ -233,16 +282,12 @@ class ToolCallGovernor:
             benign_tools=self._benign_tools,
             value_policies=self._value_policies,
         ):
-            return GovernanceDecision(
-                allowed=False,
-                reason=(
-                    f"tool {tool_name!r} has no declared data-flow role; STRICT mode "
-                    "refuses an unclassified tool (it would default to a clean read "
-                    "and arm no floor). Declare it as a source/sink/positional/"
-                    "value_policy or explicitly benign."
-                ),
-                category="unclassified_tool",
-                _normalized=normalized,
+            return _denied(
+                f"tool {tool_name!r} has no declared data-flow role; STRICT mode "
+                "refuses an unclassified tool (it would default to a clean read "
+                "and arm no floor). Declare it as a source/sink/positional/"
+                "value_policy or explicitly benign.",
+                "unclassified_tool",
             )
 
         # 1. consequence — content-blind action-class gate. (No lease/escalation

--- a/axor_core/governor.py
+++ b/axor_core/governor.py
@@ -28,6 +28,7 @@ from axor_core.contracts.anomaly import NormalizedIntent
 from axor_core.contracts.canonical import ConsequenceClass
 from axor_core.contracts.intent import Intent, IntentKind
 from axor_core.policy.normalizer import IntentNormalizer
+from axor_core.contracts.trace import IntentDeniedEvent, TraceEvent, TraceEventKind
 from axor_core.policy.gates import (
     GateDecision,
     carrier_gate,
@@ -150,6 +151,13 @@ class ToolCallGovernor:
                 raise ValueError("strict egress allowlist: " + "; ".join(errors))
         self._normalizer = IntentNormalizer()
         self._taint = TaintEngine(node_id=node_id)
+        self._node_id = node_id
+        # The SAME TraceEvents the IntentLoop emits. Both are ways of wrapping an
+        # agent, so both must feed the one instrumentation path: axor-wrap's
+        # trace bridge turns these into kernel-schema Events, and the plane and
+        # Lab read that. A gating path that decides without recording forces its
+        # consumers to invent a second trace — which is exactly what happened.
+        self._trace_events: list[TraceEvent] = []
 
     # ── decision ────────────────────────────────────────────────────────────────
 
@@ -165,6 +173,15 @@ class ToolCallGovernor:
         normalized = self._normalizer.normalize(intent)
 
         def _deny(gd: GateDecision) -> GovernanceDecision:
+            self._trace_events.append(
+                IntentDeniedEvent(
+                    kind=TraceEventKind.INTENT_DENIED,
+                    node_id=self._node_id,
+                    sequence=len(self._trace_events),
+                    intent_kind=IntentKind.TOOL_CALL.value,
+                    reason=gd.reason,
+                )
+            )
             return GovernanceDecision(
                 allowed=False, reason=gd.reason, category=gd.category,
                 _normalized=normalized,
@@ -241,7 +258,33 @@ class ToolCallGovernor:
         if gd is not None:
             return _deny(gd)
 
+        self._trace_events.append(
+            TraceEvent(
+                kind=TraceEventKind.INTENT_APPROVED,
+                node_id=self._node_id,
+                sequence=len(self._trace_events),
+                payload={"tool": tool_name},
+            )
+        )
         return GovernanceDecision(allowed=True, _normalized=normalized)
+
+    @property
+    def trace_events(self) -> "list[TraceEvent]":
+        """Every verdict this governor reached, in call order.
+
+        The kernel reports what it DECIDED; whether the caller then blocked the
+        call is the caller's business (a Lab ungoverned arm observes without
+        enforcing). So a denial is recorded here even when the wrapper chose to
+        execute anyway — otherwise an ungoverned run would have no verdicts to
+        replay, and the ungoverned/governed comparison would have nothing to
+        compare.
+        """
+        return list(self._trace_events)
+
+    def drain_trace_events(self) -> "list[TraceEvent]":
+        """Take the events and reset, for a caller streaming per trial."""
+        events, self._trace_events = self._trace_events, []
+        return events
 
     # ── ledger ────────────────────────────────────────────────────────────────
 

--- a/axor_core/governor.py
+++ b/axor_core/governor.py
@@ -80,6 +80,17 @@ GATE_OF_CATEGORY: dict[str, str] = {
 DENIAL_CATEGORIES: frozenset[str] = frozenset(GATE_OF_CATEGORY)
 
 
+def _source_tokens(sources: object) -> list[str]:
+    """Taint sources as their declared string values (`web`, `mcp`, …).
+
+    `str()` on a `(str, Enum)` member yields `TaintSource.WEB` — a Python
+    implementation detail, and these tokens go into recorded governance
+    artifacts that other languages read and hash. Emit the value the enum
+    actually declares.
+    """
+    return sorted(getattr(s, "value", None) or str(s) for s in sources or ())
+
+
 def gate_of(category: str) -> str:
     """The gate a denial category names. Unknown categories raise rather than
     passing the raw category through — a category leaking into a field that
@@ -220,7 +231,7 @@ class ToolCallGovernor:
         for name, value in args.items():
             root = self._taint.derive_value(value)
             arg_refs[name] = {
-                "sources": sorted(str(s) for s in root.sources),
+                "sources": _source_tokens(root.sources),
                 "sensitive": bool(root.sensitive),
             }
         driving_root = self._taint.derive_value(driving_subset(args, driving))
@@ -229,7 +240,7 @@ class ToolCallGovernor:
             "arg_refs": arg_refs,
             "driving_args": sorted(driving) if driving else [],
             "driving_root": {
-                "sources": sorted(str(s) for s in driving_root.sources),
+                "sources": _source_tokens(driving_root.sources),
                 "sensitive": bool(driving_root.sensitive),
             },
             "floor_active": bool(self._taint.confidentiality_floor_active()),

--- a/axor_core/governor.py
+++ b/axor_core/governor.py
@@ -28,7 +28,12 @@ from axor_core.contracts.anomaly import NormalizedIntent
 from axor_core.contracts.canonical import ConsequenceClass
 from axor_core.contracts.intent import Intent, IntentKind
 from axor_core.policy.normalizer import IntentNormalizer
-from axor_core.contracts.trace import IntentDeniedEvent, TraceEvent, TraceEventKind
+from axor_core.contracts.trace import (
+    IntentDeniedEvent,
+    TaintPropagatedEvent,
+    TraceEvent,
+    TraceEventKind,
+)
 from axor_core.policy.gates import (
     GateDecision,
     carrier_gate,
@@ -41,7 +46,14 @@ from axor_core.policy.gates import (
     value_policy_gate,
 )
 from axor_core.policy.sinks import INSTRUCTION_COMPLETE_SINKS
-from axor_core.policy.provenance import call_payload, output_root
+from axor_core.policy.provenance import (
+    ValueRefLedger,
+    call_payload,
+    declared_roles,
+    output_root,
+    result_payload,
+    source_tokens,
+)
 from axor_core.kernel.registration import (
     validate_driving_arg_allowlists,
     validate_egress_allowlists,
@@ -194,6 +206,11 @@ class ToolCallGovernor:
                 raise ValueError("strict egress allowlist: " + "; ".join(errors))
         self._normalizer = IntentNormalizer()
         self._taint = TaintEngine(node_id=node_id)
+        # The value-ref vocabulary the kernel event schema is written in. The
+        # gates decide on content derivation and need no ids; the RECORD does —
+        # `arg_refs` and `value_ref` are what let a consumer bind a denied sink
+        # argument back to the read that tainted it.
+        self._refs = ValueRefLedger()
         self._node_id = node_id
         # The SAME TraceEvents the IntentLoop emits. Both are ways of wrapping an
         # agent, so both must feed the one instrumentation path: axor-wrap's
@@ -204,7 +221,12 @@ class ToolCallGovernor:
 
     # ── decision ────────────────────────────────────────────────────────────────
 
-    def _call_payload(self, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+    def _call_payload(
+        self,
+        tool_name: str,
+        args: dict[str, Any],
+        normalized: NormalizedIntent | None = None,
+    ) -> dict[str, Any]:
         """The provenance this call was judged on — the SHARED builder.
 
         Both ways of wrapping an agent record this identical shape, from one
@@ -212,6 +234,15 @@ class ToolCallGovernor:
         """
         return call_payload(
             tool_name, args, taint=self._taint, driving_args=self._driving_args,
+            normalized=normalized, refs=self._refs,
+            roles=declared_roles(
+                tool_name,
+                untrusted_sources=self._untrusted_sources,
+                sensitive_sources=self._sensitive_sources,
+                egress_sinks=self._egress_sinks,
+                imperative_sinks=self._imperative_sinks,
+                positional_sinks=self._positional_sinks,
+            ),
         )
 
     def evaluate(self, tool_name: str, args: dict[str, Any]) -> GovernanceDecision:
@@ -236,7 +267,7 @@ class ToolCallGovernor:
                     sequence=len(self._trace_events),
                     intent_kind=IntentKind.TOOL_CALL.value,
                     reason=reason,
-                    payload={**self._call_payload(tool_name, args),
+                    payload={**self._call_payload(tool_name, args, normalized),
                              "category": category},
                 )
             )
@@ -320,7 +351,7 @@ class ToolCallGovernor:
                 kind=TraceEventKind.INTENT_APPROVED,
                 node_id=self._node_id,
                 sequence=len(self._trace_events),
-                payload=self._call_payload(tool_name, args),
+                payload=self._call_payload(tool_name, args, normalized),
             )
         )
         return GovernanceDecision(allowed=True, _normalized=normalized)
@@ -354,6 +385,13 @@ class ToolCallGovernor:
         produced value untrusted; secret/system reads also mark it sensitive,
         which arms the confidentiality floor. A clean read registers nothing.
         Call this only for calls that actually executed.
+
+        An arming read is also RECORDED, as a TAINT_PROPAGATED event carrying the
+        minted value ref and its root. Without it the trace has verdicts and no
+        source: replay has nothing to put in ``tainted_refs``, so a later
+        ``arg_refs`` binding resolves to nothing, and the Control Plane refuses
+        the run outright ("no untrusted source in the recorded run"). A clean
+        read still records nothing — it introduces no provenance to report.
         """
         ni = decision._normalized
         tool_name = ni.tool if ni is not None else ""
@@ -367,6 +405,16 @@ class ToolCallGovernor:
         if root is None:
             return  # clean read — nothing to register
         self._taint.register_value(output, root)
+        self._trace_events.append(
+            TaintPropagatedEvent(
+                kind=TraceEventKind.TAINT_PROPAGATED,
+                node_id=self._node_id,
+                sequence=len(self._trace_events),
+                taint_source=",".join(source_tokens(root.sources)),
+                taint_scope="value",
+                payload=result_payload(tool_name, self._refs.mint(output, root), root),
+            )
+        )
 
     # ── introspection ────────────────────────────────────────────────────────
 

--- a/axor_core/governor.py
+++ b/axor_core/governor.py
@@ -161,6 +161,37 @@ class ToolCallGovernor:
 
     # ── decision ────────────────────────────────────────────────────────────────
 
+    def _call_payload(self, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        """The provenance this call was judged on, in the shape the kernel event
+        schema documents for TOOL_CALL: ``arg_refs``, ``driving_root``,
+        ``floor_active``.
+
+        The governor computes all of it to reach a verdict; recording only the
+        tool name threw it away and left every consumer unable to see WHY the
+        verdict was what it was. A consumer that cannot reconstruct provenance
+        from the trace has to re-derive it, which is how a second taint ledger
+        gets built downstream.
+        """
+        driving = self._driving_args.get(tool_name)
+        arg_refs: dict[str, dict[str, Any]] = {}
+        for name, value in args.items():
+            root = self._taint.derive_value(value)
+            arg_refs[name] = {
+                "sources": sorted(str(s) for s in root.sources),
+                "sensitive": bool(root.sensitive),
+            }
+        driving_root = self._taint.derive_value(driving_subset(args, driving))
+        return {
+            "tool": tool_name,
+            "arg_refs": arg_refs,
+            "driving_args": sorted(driving) if driving else [],
+            "driving_root": {
+                "sources": sorted(str(s) for s in driving_root.sources),
+                "sensitive": bool(driving_root.sensitive),
+            },
+            "floor_active": bool(self._taint.confidentiality_floor_active()),
+        }
+
     def evaluate(self, tool_name: str, args: dict[str, Any]) -> GovernanceDecision:
         """Decide whether this tool call may execute. Pure — no side effects on
         the ledger (call :meth:`register_output` after a tool actually runs)."""
@@ -180,6 +211,8 @@ class ToolCallGovernor:
                     sequence=len(self._trace_events),
                     intent_kind=IntentKind.TOOL_CALL.value,
                     reason=gd.reason,
+                    payload={**self._call_payload(tool_name, args),
+                             "category": gd.category},
                 )
             )
             return GovernanceDecision(
@@ -263,7 +296,7 @@ class ToolCallGovernor:
                 kind=TraceEventKind.INTENT_APPROVED,
                 node_id=self._node_id,
                 sequence=len(self._trace_events),
-                payload={"tool": tool_name},
+                payload=self._call_payload(tool_name, args),
             )
         )
         return GovernanceDecision(allowed=True, _normalized=normalized)

--- a/axor_core/governor.py
+++ b/axor_core/governor.py
@@ -41,7 +41,7 @@ from axor_core.policy.gates import (
     value_policy_gate,
 )
 from axor_core.policy.sinks import INSTRUCTION_COMPLETE_SINKS
-from axor_core.policy.provenance import output_root
+from axor_core.policy.provenance import call_payload, output_root
 from axor_core.kernel.registration import (
     validate_driving_arg_allowlists,
     validate_egress_allowlists,
@@ -78,17 +78,6 @@ GATE_OF_CATEGORY: dict[str, str] = {
 }
 
 DENIAL_CATEGORIES: frozenset[str] = frozenset(GATE_OF_CATEGORY)
-
-
-def _source_tokens(sources: object) -> list[str]:
-    """Taint sources as their declared string values (`web`, `mcp`, …).
-
-    `str()` on a `(str, Enum)` member yields `TaintSource.WEB` — a Python
-    implementation detail, and these tokens go into recorded governance
-    artifacts that other languages read and hash. Emit the value the enum
-    actually declares.
-    """
-    return sorted(getattr(s, "value", None) or str(s) for s in sources or ())
 
 
 def gate_of(category: str) -> str:
@@ -216,35 +205,14 @@ class ToolCallGovernor:
     # ── decision ────────────────────────────────────────────────────────────────
 
     def _call_payload(self, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
-        """The provenance this call was judged on, in the shape the kernel event
-        schema documents for TOOL_CALL: ``arg_refs``, ``driving_root``,
-        ``floor_active``.
+        """The provenance this call was judged on — the SHARED builder.
 
-        The governor computes all of it to reach a verdict; recording only the
-        tool name threw it away and left every consumer unable to see WHY the
-        verdict was what it was. A consumer that cannot reconstruct provenance
-        from the trace has to re-derive it, which is how a second taint ledger
-        gets built downstream.
+        Both ways of wrapping an agent record this identical shape, from one
+        function, so the two cannot drift into two vocabularies.
         """
-        driving = self._driving_args.get(tool_name)
-        arg_refs: dict[str, dict[str, Any]] = {}
-        for name, value in args.items():
-            root = self._taint.derive_value(value)
-            arg_refs[name] = {
-                "sources": _source_tokens(root.sources),
-                "sensitive": bool(root.sensitive),
-            }
-        driving_root = self._taint.derive_value(driving_subset(args, driving))
-        return {
-            "tool": tool_name,
-            "arg_refs": arg_refs,
-            "driving_args": sorted(driving) if driving else [],
-            "driving_root": {
-                "sources": _source_tokens(driving_root.sources),
-                "sensitive": bool(driving_root.sensitive),
-            },
-            "floor_active": bool(self._taint.confidentiality_floor_active()),
-        }
+        return call_payload(
+            tool_name, args, taint=self._taint, driving_args=self._driving_args,
+        )
 
     def evaluate(self, tool_name: str, args: dict[str, Any]) -> GovernanceDecision:
         """Decide whether this tool call may execute. Pure — no side effects on

--- a/axor_core/kernel/events.py
+++ b/axor_core/kernel/events.py
@@ -19,8 +19,16 @@ replay agree on these keys):
   ``arg_refs``: refs are opaque value ids the fold looks up in tainted_refs and
   the subgraph walks as edges, while this is a per-argument taint summary a
   producer with no ref vocabulary (the synchronous governor) can still record,
-  "floor_active": bool}`` — ``verdict`` on the event is the recorded overall
-  gate verdict for this call; ``gate`` is the denying gate's category if denied.
+  "floor_active": bool, "roles": {"untrusted_source", "sensitive_source",
+  "egress_sink", "imperative_sink", "positional_sink"} — the OPERATOR's declared
+  data-flow roles for this tool, which is what the taint gate keys on and what
+  ``normalized`` cannot tell you: the normalizer classifies structurally from the
+  tool's name, so a deployment's ``send_email`` normalises to
+  ``destination_kind: none`` and looks like a local no-op}`` — ``verdict`` on the
+  event is the recorded overall gate verdict for this call; ``gate`` is the
+  denying gate's category if denied. A REFUSED tool call is a TOOL_CALL with
+  ``verdict: deny``, not a DENIAL: this branch is the only one replay re-gates,
+  and DENIAL is for refusals that are not tool calls (a spawn, a message).
 - TOOL_RESULT: ``{"tool", "status", "value_ref", "root": {"sources": [...],
   "sensitive"}}`` — registers ``value_ref`` in the taint fold.
 - FAULT_INJECTED: ``{"tool", "mode", "canary"}``

--- a/axor_core/kernel/events.py
+++ b/axor_core/kernel/events.py
@@ -15,6 +15,10 @@ replay agree on these keys):
 
 - TOOL_CALL: ``{"tool", "args", "arg_refs": {arg: value_ref}, "normalized":
   {NormalizedIntent fields}, "driving_root": {"sources": [...], "sensitive"},
+  "arg_provenance": {arg: {"sources": [...], "sensitive"}} — OPTIONAL, and NOT
+  ``arg_refs``: refs are opaque value ids the fold looks up in tainted_refs and
+  the subgraph walks as edges, while this is a per-argument taint summary a
+  producer with no ref vocabulary (the synchronous governor) can still record,
   "floor_active": bool}`` — ``verdict`` on the event is the recorded overall
   gate verdict for this call; ``gate`` is the denying gate's category if denied.
 - TOOL_RESULT: ``{"tool", "status", "value_ref", "root": {"sources": [...],

--- a/axor_core/kernel/replay.py
+++ b/axor_core/kernel/replay.py
@@ -165,14 +165,37 @@ def _derive_driving_root(
     if not arg_refs:
         return root_from_payload(payload.get("driving_root"))
     roots = []
+    excised = False
+    unresolved = False
     for ref in arg_refs.values():
         if ref in state.excised_refs:
+            excised = True
             continue  # excision removes future influence (spec 8.2.1)
+        known = False
         if ref in state.tainted_refs:
             roots.append(state.tainted_refs[ref])
+            known = True
         if ref in config.synthetic_taint_refs:
             roots.append(CausalRoot.cross_process_in())
-    return CausalRoot.mint(*roots) if roots else CausalRoot.constant()
+            known = True
+        if not known:
+            unresolved = True
+    if roots:
+        return CausalRoot.mint(*roots)
+    if excised:
+        # A deliberate operator counterfactual: the ref stops influencing future
+        # derivations, so a clean root here is the ANSWER, not missing data.
+        return CausalRoot.constant()
+    if unresolved:
+        # Every ref is unknown to this fold — the TOOL_RESULT that minted them is
+        # not in the events being folded (a bridge dropped it, a partial window,
+        # a run stitched from one node's slice). Returning clean here re-decides
+        # a recorded DENY as ALLOW: silently fail-open, on missing data, in the
+        # exact direction that hides a breach. The producer recorded the root it
+        # actually gated on; fall back to it, the same as for a payload with no
+        # refs at all.
+        return root_from_payload(payload.get("driving_root"))
+    return CausalRoot.constant()
 
 
 def evaluate_call(

--- a/axor_core/node/intent_loop.py
+++ b/axor_core/node/intent_loop.py
@@ -30,7 +30,7 @@ from axor_core.kernel.registration import (
 )
 from axor_core.taint.engine import TaintEngine
 from axor_core.policy.sinks import INSTRUCTION_COMPLETE_SINKS
-from axor_core.policy.provenance import output_root
+from axor_core.policy.provenance import call_payload, output_root
 from axor_core.contracts.result import ExecutorEvent, ExecutorEventKind
 from axor_core.contracts.trace import (
     CancelledEvent,
@@ -840,7 +840,10 @@ class IntentLoop:
                 kind=TraceEventKind.INTENT_TRANSFORMED if is_transform else TraceEventKind.INTENT_APPROVED,
                 node_id=envelope.node_id,
                 sequence=len(self._trace_events),
-                payload={"tool": tool_name},
+                # the SHARED payload builder — the synchronous governor records
+                # the identical shape from the identical function, so the two
+                # ways of wrapping an agent cannot drift into two vocabularies.
+                payload=self._call_payload(tool_name, tool_args),
             )
         )
 
@@ -1093,12 +1096,29 @@ class IntentLoop:
         )
         return gd.reason if gd is not None else None
 
+    def _call_payload(self, tool_name: str, args: dict) -> dict:
+        """The provenance a verdict was reached on — the SHARED builder, the one
+        ``ToolCallGovernor`` uses. Recording only the tool name left every
+        consumer re-deriving provenance the kernel had already computed."""
+        return call_payload(
+            tool_name, args, taint=self._taint_engine, driving_args=self._driving_args,
+        )
+
     def _record_denial(
         self,
         intent: Intent,
         reason: str,
         envelope: ExecutionEnvelope,
     ) -> None:
+        payload: dict = {}
+        if intent.kind is IntentKind.TOOL_CALL and self._taint_engine is not None:
+            # a denied call carries the provenance it was denied ON. Without it a
+            # consumer can see THAT the kernel refused but not what it refused
+            # over — and an operator asking "why" gets nothing.
+            body = intent.payload if isinstance(intent.payload, dict) else {}
+            payload = self._call_payload(
+                str(body.get("tool", "")), dict(body.get("args") or {}),
+            )
         self._trace_events.append(
             IntentDeniedEvent(
                 kind=TraceEventKind.INTENT_DENIED,
@@ -1106,6 +1126,7 @@ class IntentLoop:
                 sequence=len(self._trace_events),
                 intent_kind=intent.kind.value,
                 reason=reason,
+                payload=payload,
             )
         )
 

--- a/axor_core/node/intent_loop.py
+++ b/axor_core/node/intent_loop.py
@@ -30,12 +30,20 @@ from axor_core.kernel.registration import (
 )
 from axor_core.taint.engine import TaintEngine
 from axor_core.policy.sinks import INSTRUCTION_COMPLETE_SINKS
-from axor_core.policy.provenance import call_payload, output_root
+from axor_core.policy.provenance import (
+    ValueRefLedger,
+    call_payload,
+    declared_roles,
+    output_root,
+    result_payload,
+    source_tokens,
+)
 from axor_core.contracts.result import ExecutorEvent, ExecutorEventKind
 from axor_core.contracts.trace import (
     CancelledEvent,
     IntentDeniedEvent,
     SinkDensityEvent,
+    TaintPropagatedEvent,
     TokensSpentEvent,
     TraceEvent,
     TraceEventKind,
@@ -174,6 +182,11 @@ class IntentLoop:
         self._degradation_engine = degradation_engine
         self._reputation_enricher = reputation_enricher
         self._normalizer = IntentNormalizer()
+        # The value-ref vocabulary the kernel event schema is written in — the
+        # same ledger the synchronous governor keeps, so both paths record refs
+        # the replay fold and the plane's value graph can resolve.
+        self._value_refs = ValueRefLedger()
+        self._normalized_of_call: NormalizedIntent | None = None
         self._intent_sequence = 0
         self._token_totals = _TokenAccumulator()
         # DoS guards — opt-in (None = unlimited). GovernedSession sets prod defaults.
@@ -599,6 +612,11 @@ class IntentLoop:
                 self._degradation_engine.record_detection(normalized)
                 for ev in self._degradation_engine.drain_events():
                     self._trace_events.append(ev)
+        # Stashed for `_call_payload`: a denial can be recorded from a dozen
+        # places in this method, and threading the projection through every one
+        # of them is how one of them ends up recording a call with no
+        # `normalized` block — which replay then re-gates as a local no-op.
+        self._normalized_of_call = normalized
 
         # STRICT role completeness (lazy, per call): an unclassified tool fails
         # closed instead of defaulting to a clean benign read. Mirrors the governor;
@@ -1101,8 +1119,22 @@ class IntentLoop:
         """The provenance a verdict was reached on — the SHARED builder, the one
         ``ToolCallGovernor`` uses. Recording only the tool name left every
         consumer re-deriving provenance the kernel had already computed."""
+        normalized = self._normalized_of_call
+        if normalized is not None and normalized.tool != tool_name:
+            # a spawn/message denial recorded while a tool call's projection is
+            # still stashed — better no block than another call's.
+            normalized = None
         return call_payload(
             tool_name, args, taint=self._taint_engine, driving_args=self._driving_args,
+            normalized=normalized, refs=self._value_refs,
+            roles=declared_roles(
+                tool_name,
+                untrusted_sources=self._untrusted_sources,
+                sensitive_sources=self._sensitive_sources,
+                egress_sinks=self._egress_sinks,
+                imperative_sinks=self._imperative_sinks,
+                positional_sinks=self._positional_sinks,
+            ),
         )
 
     def _record_denial(
@@ -1150,11 +1182,18 @@ class IntentLoop:
         `override_root` short-circuits the structural derivation — used when the
         federation gateway has already decided the value's provenance (a peer value
         whose receipt was restored or re-minted untrusted).
+
+        An arming read is also RECORDED (see :meth:`_record_taint_propagated`):
+        the trace's only statement of where taint entered the run.
         """
         if self._taint_engine is None:
             return
         if override_root is not None:
             self._taint_engine.register_value(result, override_root)
+            self._record_taint_propagated(
+                effective_intent.node_id,
+                str(effective_intent.payload.get("tool", "")), result, override_root,
+            )
             return
         tool_name = effective_intent.payload.get("tool", "")
         # Shared arming map (policy.provenance.output_root) — the same mapping the
@@ -1170,6 +1209,34 @@ class IntentLoop:
         if root is None:
             return  # clean read — nothing to register
         self._taint_engine.register_value(result, root)
+        self._record_taint_propagated(
+            effective_intent.node_id, str(tool_name), result, root,
+        )
+
+    def _record_taint_propagated(
+        self, node_id: str, tool_name: str, result: Any, root: "CausalRoot",
+    ) -> None:
+        """Record the read that introduced provenance, with its minted value ref.
+
+        This is the trace's SOURCE event. Without it a run is a list of verdicts
+        with no origin: the replay fold has nothing to put in ``tainted_refs``,
+        so a later ``arg_refs`` binding resolves to nothing, and the Control
+        Plane refuses the run ("no untrusted source in the recorded run"). The
+        synchronous governor records the identical payload from the identical
+        builder — the two paths must not differ on what a source looks like.
+        """
+        self._trace_events.append(
+            TaintPropagatedEvent(
+                kind=TraceEventKind.TAINT_PROPAGATED,
+                node_id=node_id,
+                sequence=len(self._trace_events),
+                taint_source=",".join(source_tokens(root.sources)),
+                taint_scope="value",
+                payload=result_payload(
+                    tool_name, self._value_refs.mint(result, root), root,
+                ),
+            )
+        )
 
     def _check_consequence(
         self,

--- a/axor_core/node/intent_loop.py
+++ b/axor_core/node/intent_loop.py
@@ -378,7 +378,8 @@ class IntentLoop:
                         )
                         if spawn_decision.kind == PolicyDecisionKind.DENY:
                             self._record_denial(
-                                spawn_intent, spawn_decision.reason, envelope
+                                spawn_intent, spawn_decision.reason, envelope,
+                                "capability",
                             )
                             denial = _denial_result(tool_name, spawn_decision.reason)
                             if self._tool_result_callback is not None:
@@ -403,7 +404,7 @@ class IntentLoop:
                         spawn_args = event.payload.get("args", {})
                         taint_reason = self._spawn_taint_reason(spawn_args)
                         if taint_reason is not None:
-                            self._record_denial(spawn_intent, taint_reason, envelope)
+                            self._record_denial(spawn_intent, taint_reason, envelope, "taint_enforcement")
                             denial = _denial_result(tool_name, taint_reason)
                             if self._tool_result_callback is not None:
                                 await self._tool_result_callback(
@@ -518,7 +519,7 @@ class IntentLoop:
             reason = (
                 f"session intent limit reached ({self._max_intents_per_session})"
             )
-            self._record_denial(intent, reason, envelope)
+            self._record_denial(intent, reason, envelope, "budget")
             return ResolvedIntent(
                 intent=intent,
                 approved=False,
@@ -529,7 +530,7 @@ class IntentLoop:
         decision, pending_consumption = self._evaluate_tool_intent(intent, envelope)
 
         if decision.kind == PolicyDecisionKind.DENY:
-            self._record_denial(intent, decision.reason, envelope)
+            self._record_denial(intent, decision.reason, envelope, "capability")
             denial_resp = _make_denial_response(decision.reason)
             self._record_degradation_signal(intent, denial_resp)
             return ResolvedIntent(
@@ -566,7 +567,7 @@ class IntentLoop:
                 f"+{self._tool_weight(tool_name)} for '{tool_name}')"
             )
         if budget_reason is not None:
-            self._record_denial(intent, budget_reason, envelope)
+            self._record_denial(intent, budget_reason, envelope, "budget")
             denial_resp = _make_denial_response(budget_reason, "budget")
             self._record_degradation_signal(intent, denial_resp)
             return ResolvedIntent(
@@ -617,7 +618,7 @@ class IntentLoop:
                 "refuses an unclassified tool (it would default to a clean read and "
                 "arm no floor)"
             )
-            self._record_denial(intent, role_denial, envelope)
+            self._record_denial(intent, role_denial, envelope, "unclassified_tool")
             denial_resp = _make_denial_response(role_denial, "unclassified_tool")
             self._record_degradation_signal(intent, denial_resp)
             return ResolvedIntent(
@@ -637,7 +638,7 @@ class IntentLoop:
             operation=normalized.operation if normalized is not None else None,
         )
         if consequence_denial is not None:
-            self._record_denial(intent, consequence_denial, envelope)
+            self._record_denial(intent, consequence_denial, envelope, "consequence_gate")
             denial_resp = _make_denial_response(consequence_denial, "consequence_gate")
             self._record_degradation_signal(intent, denial_resp)
             return ResolvedIntent(
@@ -653,7 +654,7 @@ class IntentLoop:
         # by decidable decision procedures.
         value_denial = check_value_policies(tool_name, tool_args, self._value_policies)
         if value_denial is not None:
-            self._record_denial(intent, value_denial, envelope)
+            self._record_denial(intent, value_denial, envelope, "value_policy")
             denial_resp = _make_denial_response(value_denial, "value_policy")
             self._record_degradation_signal(intent, denial_resp)
             return ResolvedIntent(
@@ -684,7 +685,7 @@ class IntentLoop:
                 tool_name, normalized, envelope, driving_root=check_root
             )
             if degradation_denial is not None:
-                self._record_denial(intent, degradation_denial, envelope)
+                self._record_denial(intent, degradation_denial, envelope, "degradation")
                 denial_resp = _make_denial_response(degradation_denial)
                 self._record_degradation_signal(intent, denial_resp, normalized)
                 return ResolvedIntent(
@@ -696,7 +697,7 @@ class IntentLoop:
 
         # Shared gate denial → ResolvedIntent (records denial + degradation signal).
         def _gate_denial(gd) -> ResolvedIntent:
-            self._record_denial(intent, gd.reason, envelope)
+            self._record_denial(intent, gd.reason, envelope, gd.category)
             denial_resp = _make_denial_response(gd.reason, gd.category)
             self._record_degradation_signal(intent, denial_resp, normalized)
             return ResolvedIntent(
@@ -811,7 +812,7 @@ class IntentLoop:
                     f"adjudicator (advisory): denied '{tool_name}' on its "
                     f"projection (hash {projection_hash(projection)})"
                 )
-                self._record_denial(intent, reason, envelope)
+                self._record_denial(intent, reason, envelope, "budget")
                 denial_resp = _make_denial_response(reason, "adjudicator")
                 self._record_degradation_signal(intent, denial_resp, normalized)
                 return ResolvedIntent(
@@ -874,7 +875,7 @@ class IntentLoop:
                     )
                 except FederationError as exc:
                     reason = f"federation: rejected peer value — {exc}"
-                    self._record_denial(intent, reason, envelope)
+                    self._record_denial(intent, reason, envelope, "budget")
                     denial_resp = _make_denial_response(reason, "federation_gate")
                     return ResolvedIntent(
                         intent=intent, approved=False, reason=reason,
@@ -902,7 +903,7 @@ class IntentLoop:
             )
         except _KNOWN_TOOL_EXCEPTIONS as exc:
             reason = str(exc)
-            self._record_denial(intent, reason, envelope)
+            self._record_denial(intent, reason, envelope, "budget")
             return ResolvedIntent(
                 intent=intent,
                 approved=False,
@@ -923,7 +924,7 @@ class IntentLoop:
                 tb,
             )
             reason = f"tool execution failed: {type(exc).__name__}: {exc}"
-            self._record_denial(intent, reason, envelope)
+            self._record_denial(intent, reason, envelope, "budget")
             return ResolvedIntent(
                 intent=intent,
                 approved=False,
@@ -1109,6 +1110,7 @@ class IntentLoop:
         intent: Intent,
         reason: str,
         envelope: ExecutionEnvelope,
+        category: str = "capability",
     ) -> None:
         payload: dict = {}
         if intent.kind is IntentKind.TOOL_CALL and self._taint_engine is not None:
@@ -1119,6 +1121,10 @@ class IntentLoop:
             payload = self._call_payload(
                 str(body.get("tool", "")), dict(body.get("args") or {}),
             )
+        # the category NAMES the gate a consumer records. Without it a denial can
+        # only be written as "refused, somehow", and trace/v1's `gate` field —
+        # which takes a gate name, not a category — has nothing to fill in.
+        payload["category"] = category
         self._trace_events.append(
             IntentDeniedEvent(
                 kind=TraceEventKind.INTENT_DENIED,

--- a/axor_core/policy/provenance.py
+++ b/axor_core/policy/provenance.py
@@ -77,8 +77,20 @@ def call_payload(
 ) -> "dict[str, object]":
     """The provenance a tool-call verdict was reached on.
 
-    The shape the kernel event schema documents for TOOL_CALL: ``arg_refs``,
-    ``driving_args``, ``driving_root``, ``floor_active``.
+    ``driving_root`` is the shape the kernel event schema documents for
+    TOOL_CALL, and ``kernel.replay.root_from_payload`` reads it directly.
+
+    The per-argument breakdown goes under ``arg_provenance``, NOT ``arg_refs``.
+    That distinction is load-bearing and this got it wrong: the schema's
+    ``arg_refs`` is ``{arg: value_ref}`` — a mapping to opaque value REFERENCES
+    that ``replay._derive_driving_root`` looks up in ``state.tainted_refs`` and
+    ``subgraph`` walks as edges. Writing a nested provenance dict there crashed
+    the replay fold outright (`TypeError: unhashable type: 'dict'`).
+
+    This governor has no value-ref vocabulary — it derives taint from content,
+    not from minted ids — so it must leave ``arg_refs`` alone and let replay
+    take its documented fallback to ``driving_root``, which is what the verdict
+    turned on anyway.
 
     Shared by BOTH ways of wrapping an agent — ``ToolCallGovernor`` (the
     synchronous per-call path) and ``IntentLoop`` (the async streaming path) —
@@ -91,17 +103,17 @@ def call_payload(
     from axor_core.policy.gates import driving_subset
 
     driving = (driving_args or {}).get(tool_name)
-    arg_refs: dict[str, object] = {}
+    arg_provenance: dict[str, object] = {}
     for name, value in (args or {}).items():
         root = taint.derive_value(value)  # type: ignore[attr-defined]
-        arg_refs[name] = {
+        arg_provenance[name] = {
             "sources": source_tokens(root.sources),
             "sensitive": bool(root.sensitive),
         }
     driving_root = taint.derive_value(driving_subset(args or {}, driving))  # type: ignore[attr-defined]
     return {
         "tool": tool_name,
-        "arg_refs": arg_refs,
+        "arg_provenance": arg_provenance,
         "driving_args": sorted(driving) if driving else [],
         "driving_root": {
             "sources": source_tokens(driving_root.sources),

--- a/axor_core/policy/provenance.py
+++ b/axor_core/policy/provenance.py
@@ -56,3 +56,56 @@ def output_root(
         )
         return CausalRoot.external_read(TaintSource.FILE, sensitive=sensitive)
     return None
+
+
+def source_tokens(sources: object) -> list[str]:
+    """Taint sources as their declared string values (`web`, `mcp`, …).
+
+    ``str()`` on a ``(str, Enum)`` member yields ``TaintSource.WEB`` — a Python
+    implementation detail, and these tokens go into recorded governance
+    artifacts that other languages read and hash.
+    """
+    return sorted(getattr(s, "value", None) or str(s) for s in sources or ())
+
+
+def call_payload(
+    tool_name: str,
+    args: "dict[str, object]",
+    *,
+    taint: object,
+    driving_args: "dict[str, frozenset[str]] | dict[str, set[str]] | None" = None,
+) -> "dict[str, object]":
+    """The provenance a tool-call verdict was reached on.
+
+    The shape the kernel event schema documents for TOOL_CALL: ``arg_refs``,
+    ``driving_args``, ``driving_root``, ``floor_active``.
+
+    Shared by BOTH ways of wrapping an agent — ``ToolCallGovernor`` (the
+    synchronous per-call path) and ``IntentLoop`` (the async streaming path) —
+    because they are two entry points to one kernel, not two kernels. Each
+    computed this provenance to reach a verdict and then recorded only the tool
+    name, so every consumer had to re-derive it from raw arguments, which is how
+    a second taint ledger gets built downstream. Living in one function is what
+    stops the two paths from drifting into two vocabularies.
+    """
+    from axor_core.policy.gates import driving_subset
+
+    driving = (driving_args or {}).get(tool_name)
+    arg_refs: dict[str, object] = {}
+    for name, value in (args or {}).items():
+        root = taint.derive_value(value)  # type: ignore[attr-defined]
+        arg_refs[name] = {
+            "sources": source_tokens(root.sources),
+            "sensitive": bool(root.sensitive),
+        }
+    driving_root = taint.derive_value(driving_subset(args or {}, driving))  # type: ignore[attr-defined]
+    return {
+        "tool": tool_name,
+        "arg_refs": arg_refs,
+        "driving_args": sorted(driving) if driving else [],
+        "driving_root": {
+            "sources": source_tokens(driving_root.sources),
+            "sensitive": bool(driving_root.sensitive),
+        },
+        "floor_active": bool(taint.confidentiality_floor_active()),  # type: ignore[attr-defined]
+    }

--- a/axor_core/policy/provenance.py
+++ b/axor_core/policy/provenance.py
@@ -68,12 +68,136 @@ def source_tokens(sources: object) -> list[str]:
     return sorted(getattr(s, "value", None) or str(s) for s in sources or ())
 
 
+class ValueRefLedger:
+    """Mints a value id per registered tool output and answers which ids a
+    later value was derived from.
+
+    The kernel event schema is written in value REFS: ``TOOL_RESULT`` mints
+    ``value_ref``, ``TOOL_CALL`` binds ``arg_refs = {arg: value_ref}``, the
+    replay fold resolves those refs against ``state.tainted_refs``, and
+    ``subgraph`` walks them as edges. Neither wrapping path spoke that
+    vocabulary — both derive taint from CONTENT — so both recorded verdicts with
+    no refs at all. Replay still folded them (it falls back to ``driving_root``),
+    but every downstream consumer that reasons over the value graph got nothing:
+    the Control Plane's incident converter reads ``arg_refs`` to bind a sink's
+    driving argument to the value that tainted it, and with no refs it cannot
+    reproduce a recorded DENY, so it refuses the whole run.
+
+    Refs are minted here and resolved with the SAME content derivation the gates
+    decide on — one :class:`ValueTaintLedger` per registered value, queried with
+    the same ``derive`` — so a ref can never claim a link the verdict did not
+    turn on, or miss one it did.
+
+    Ids are ``v1``, ``v2``, … in registration order: deterministic, so two runs
+    of the same session produce byte-identical traces.
+    """
+
+    __slots__ = ("_entries",)
+
+    def __init__(self) -> None:
+        # (ref, single-value ledger, root) in registration order
+        self._entries: list[tuple[str, object, object]] = []
+
+    def mint(self, content: object, root: object) -> str:
+        """Register ``content`` under a fresh ref and return it."""
+        from axor_core.taint.ledger import ValueTaintLedger
+
+        ledger = ValueTaintLedger()
+        ledger.register(content, root)  # type: ignore[arg-type]
+        ref = f"v{len(self._entries) + 1}"
+        self._entries.append((ref, ledger, root))
+        return ref
+
+    def refs_for(self, value: object) -> list[str]:
+        """Every minted ref whose content this value carries, oldest first."""
+        out: list[str] = []
+        for ref, ledger, _root in self._entries:
+            derived = ledger.derive(value)  # type: ignore[attr-defined]
+            if derived.is_tainted or derived.sensitive:
+                out.append(ref)
+        return out
+
+    def ref_for(self, value: object) -> str | None:
+        """The most recent ref this value carries, or None.
+
+        ``arg_refs`` is one ref per argument, so an argument splicing two
+        registered values can only name one. The most recent is the closer
+        cause; the joined taint the verdict turned on is recorded whole in
+        ``driving_root`` either way, so this choice narrows the value GRAPH, not
+        the verdict.
+        """
+        refs = self.refs_for(value)
+        return refs[-1] if refs else None
+
+
+def declared_roles(
+    tool_name: str,
+    *,
+    untrusted_sources: "frozenset[str] | set[str]" = frozenset(),
+    sensitive_sources: "frozenset[str] | set[str]" = frozenset(),
+    egress_sinks: "frozenset[str] | set[str]" = frozenset(),
+    imperative_sinks: "frozenset[str] | set[str]" = frozenset(),
+    positional_sinks: "frozenset[str] | set[str]" = frozenset(),
+) -> "dict[str, bool]":
+    """The data-flow roles the OPERATOR declared for this tool.
+
+    ``normalized`` is the normalizer's structural guess from the tool's name and
+    arguments, and it does not recognise a deployment's own vocabulary: a tool
+    called ``send_email`` normalises to ``destination_kind: none``, an ordinary
+    local call. What makes it an egress sink is the operator declaring it one —
+    ``egress_sinks={"send_email"}`` — which is what ``taint_gate`` actually keys
+    on when it denies.
+
+    That declaration was never recorded, so a consumer reading the trace saw a
+    DENY on a call that looks, by every field present, like a harmless local
+    operation. The Control Plane's converter reads egress-ness off
+    ``destination_kind`` alone, concluded the run contained no sink at all, and
+    refused it — "no recorded egress consequence" — for a run whose whole point
+    was a blocked exfiltration.
+    """
+    return {
+        "untrusted_source": tool_name in untrusted_sources,
+        "sensitive_source": tool_name in sensitive_sources,
+        "egress_sink": tool_name in egress_sinks,
+        "imperative_sink": tool_name in imperative_sinks,
+        "positional_sink": tool_name in positional_sinks,
+    }
+
+
+def normalized_payload(normalized: object) -> "dict[str, object]":
+    """The structural projection a recorded call was gated on.
+
+    ``kernel.replay.normalized_from_payload`` reads exactly these keys and
+    defaults every missing one to the benign value (``operation="other"``,
+    ``destination_kind="none"``, …). Omitting the block therefore does not make
+    replay abstain — it makes replay re-gate the call as a local no-op, so the
+    ssrf / consequence / carrier gates silently cannot fire and a recorded DENY
+    comes back ALLOW. The Control Plane reads ``destination_kind`` from here to
+    tell an egress sink from a read at all.
+    """
+    return {
+        "operation": normalized.operation,  # type: ignore[attr-defined]
+        "target_kind": normalized.target_kind,  # type: ignore[attr-defined]
+        "destination_kind": normalized.destination_kind,  # type: ignore[attr-defined]
+        "provenance": normalized.provenance,  # type: ignore[attr-defined]
+        "reads_secret_like_data": bool(normalized.reads_secret_like_data),  # type: ignore[attr-defined]
+        "writes_outside_workdir": bool(normalized.writes_outside_workdir),  # type: ignore[attr-defined]
+        "executes_generated_code": bool(normalized.executes_generated_code),  # type: ignore[attr-defined]
+        "after_external_read": bool(normalized.after_external_read),  # type: ignore[attr-defined]
+        "after_secret_access": bool(normalized.after_secret_access),  # type: ignore[attr-defined]
+        "data_flow": normalized.data_flow,  # type: ignore[attr-defined]
+    }
+
+
 def call_payload(
     tool_name: str,
     args: "dict[str, object]",
     *,
     taint: object,
     driving_args: "dict[str, frozenset[str]] | dict[str, set[str]] | None" = None,
+    normalized: object = None,
+    refs: "ValueRefLedger | None" = None,
+    roles: "dict[str, bool] | None" = None,
 ) -> "dict[str, object]":
     """The provenance a tool-call verdict was reached on.
 
@@ -87,10 +211,11 @@ def call_payload(
     ``subgraph`` walks as edges. Writing a nested provenance dict there crashed
     the replay fold outright (`TypeError: unhashable type: 'dict'`).
 
-    This governor has no value-ref vocabulary — it derives taint from content,
-    not from minted ids — so it must leave ``arg_refs`` alone and let replay
-    take its documented fallback to ``driving_root``, which is what the verdict
-    turned on anyway.
+    ``arg_refs`` is populated only when the caller supplies a
+    :class:`ValueRefLedger` — the refs then come from the same content
+    derivation the gates decided on, so they cannot disagree with the verdict.
+    Without one the key is absent and replay takes its documented fallback to
+    ``driving_root``.
 
     Shared by BOTH ways of wrapping an agent — ``ToolCallGovernor`` (the
     synchronous per-call path) and ``IntentLoop`` (the async streaming path) —
@@ -104,15 +229,24 @@ def call_payload(
 
     driving = (driving_args or {}).get(tool_name)
     arg_provenance: dict[str, object] = {}
+    arg_refs: dict[str, str] = {}
     for name, value in (args or {}).items():
         root = taint.derive_value(value)  # type: ignore[attr-defined]
         arg_provenance[name] = {
             "sources": source_tokens(root.sources),
             "sensitive": bool(root.sensitive),
         }
+        if refs is not None:
+            ref = refs.ref_for(value)
+            if ref is not None:
+                arg_refs[name] = ref
     driving_root = taint.derive_value(driving_subset(args or {}, driving))  # type: ignore[attr-defined]
-    return {
+    payload: dict[str, object] = {
         "tool": tool_name,
+        # the raw arguments the call was made with. Replay re-gates on these —
+        # `evaluate_call` runs the value-policy and positional gates over them —
+        # so a payload without `args` re-decides an egress call on an empty dict.
+        "args": dict(args or {}),
         "arg_provenance": arg_provenance,
         "driving_args": sorted(driving) if driving else [],
         "driving_root": {
@@ -120,4 +254,35 @@ def call_payload(
             "sensitive": bool(driving_root.sensitive),
         },
         "floor_active": bool(taint.confidentiality_floor_active()),  # type: ignore[attr-defined]
+    }
+    if arg_refs:
+        payload["arg_refs"] = arg_refs
+    if normalized is not None:
+        payload["normalized"] = normalized_payload(normalized)
+    if roles is not None:
+        payload["roles"] = dict(roles)
+    return payload
+
+
+def result_payload(
+    tool_name: str, value_ref: str, root: object,
+) -> "dict[str, object]":
+    """The TOOL_RESULT payload for an executed tool whose output armed taint.
+
+    This is the event that makes a trace have a SOURCE. The replay fold
+    registers ``value_ref`` under ``root`` in ``state.tainted_refs`` — which is
+    what makes a later ``arg_refs`` binding resolve to anything — and the
+    Control Plane's incident converter requires at least one of these before it
+    will accept a run at all ("no untrusted source in the recorded run").
+    Neither wrapping path emitted one, so every trace either path produced was a
+    sequence of verdicts with no explanation of where the taint came from.
+    """
+    return {
+        "tool": tool_name,
+        "status": "ok",
+        "value_ref": value_ref,
+        "root": {
+            "sources": source_tokens(root.sources),  # type: ignore[attr-defined]
+            "sensitive": bool(root.sensitive),  # type: ignore[attr-defined]
+        },
     }

--- a/tests/test_both_wrap_paths_emit.py
+++ b/tests/test_both_wrap_paths_emit.py
@@ -109,9 +109,14 @@ class TestTheVerdictCarriesItsProvenance(unittest.TestCase):
     """Recording only the tool name is what forces a consumer to build a second
     taint ledger: the trace says a call was denied but not what it was denied
     ON, so anything wanting to show the operator *why* has to re-derive the
-    provenance the kernel already computed. The kernel event schema documents
-    ``arg_refs`` / ``driving_root`` / ``floor_active`` for TOOL_CALL — this is
-    the path that fills them in."""
+    provenance the kernel already computed.
+
+    It goes under ``arg_provenance``, not the schema's ``arg_refs``: that field
+    is ``{arg: value_ref}`` — opaque ids the replay fold looks up and the
+    subgraph walks as edges — and filling it with nested dicts crashed the fold
+    (`TypeError: unhashable type: 'dict'`). See
+    `test_governor_payload_survives_replay.py`, which puts these bytes through
+    the real fold rather than comparing them to a docstring."""
 
     def _denial(self):
         governor = _governor()
@@ -127,17 +132,17 @@ class TestTheVerdictCarriesItsProvenance(unittest.TestCase):
 
     def test_each_argument_carries_the_sources_it_was_derived_from(self) -> None:
         payload = self._denial()
-        self.assertEqual(sorted(payload["arg_refs"]), ["recipient"])
-        self.assertTrue(payload["arg_refs"]["recipient"]["sources"])
+        self.assertEqual(sorted(payload["arg_provenance"]), ["recipient"])
+        self.assertTrue(payload["arg_provenance"]["recipient"]["sources"])
 
     def test_the_driving_root_is_the_join_over_the_declared_driving_args(self) -> None:
         """The verdict turns on the driving root, not on every argument, so a
-        consumer reading only ``arg_refs`` could not tell an incidental tainted
-        argument from the one that actually caused the denial."""
+        consumer reading only the per-argument breakdown could not tell an
+        incidental tainted argument from the one that caused the denial."""
         payload = self._denial()
         self.assertEqual(payload["driving_args"], ["recipient"])
         self.assertEqual(
-            payload["driving_root"]["sources"], payload["arg_refs"]["recipient"]["sources"],
+            payload["driving_root"]["sources"], payload["arg_provenance"]["recipient"]["sources"],
         )
 
     def test_a_denial_carries_its_category(self) -> None:
@@ -150,7 +155,7 @@ class TestTheVerdictCarriesItsProvenance(unittest.TestCase):
         governor = _governor()
         governor.evaluate("send_money", {"recipient": "self"})
         payload = governor.trace_events[-1].payload
-        self.assertEqual(payload["arg_refs"]["recipient"]["sources"], [])
+        self.assertEqual(payload["arg_provenance"]["recipient"]["sources"], [])
         self.assertFalse(payload["driving_root"]["sensitive"])
 
     def test_the_floor_state_is_reported(self) -> None:

--- a/tests/test_both_wrap_paths_emit.py
+++ b/tests/test_both_wrap_paths_emit.py
@@ -1,0 +1,129 @@
+"""Both ways of wrapping an agent record the same trace.
+
+axor-core gates through two entry points, and they are not competing designs —
+they are two ways of wrapping an agent:
+
+  - ``GovernedNode`` / ``IntentLoop`` — the async, streaming path.
+  - ``ToolCallGovernor`` — the synchronous, per-call path axor-wrap builds on.
+
+Both must feed the ONE instrumentation path, because axor-wrap's trace bridge
+turns ``TraceEvent``s into kernel-schema events and both Lab and the Control
+Plane read that single feed. While the synchronous path decided without
+recording, its only consumer had nothing to push — which is how a second,
+parallel trace gets invented downstream to fill the gap.
+
+So the invariant is not "the governor emits something". It is that it emits the
+SAME event kinds the IntentLoop emits, so one bridge and one replay fold serve
+both.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from axor_core.contracts.trace import TraceEventKind
+from axor_core.governor import ToolCallGovernor
+
+# The kinds the IntentLoop emits for a tool-call verdict (intent_loop.py: the
+# approved/transformed emit, and _record_denial).
+INTENT_LOOP_VERDICT_KINDS = {
+    TraceEventKind.INTENT_APPROVED,
+    TraceEventKind.INTENT_DENIED,
+}
+
+
+def _governor() -> ToolCallGovernor:
+    return ToolCallGovernor(
+        untrusted_sources={"read_txns"},
+        egress_sinks={"send_money"},
+        driving_args={"send_money": {"recipient"}},
+    )
+
+
+class TestTheSynchronousPathRecords(unittest.TestCase):
+    def test_an_approval_is_recorded(self) -> None:
+        governor = _governor()
+        decision = governor.evaluate("read_txns", {})
+        self.assertTrue(decision.allowed)
+        self.assertEqual(
+            [e.kind for e in governor.trace_events], [TraceEventKind.INTENT_APPROVED],
+        )
+
+    def test_a_denial_is_recorded(self) -> None:
+        governor = _governor()
+        approved = governor.evaluate("read_txns", {})
+        governor.register_output(approved, {"description": "PAY DE89370400440532013000"})
+        denied = governor.evaluate(
+            "send_money", {"recipient": "PAY DE89370400440532013000"},
+        )
+        self.assertFalse(denied.allowed)
+        self.assertEqual(
+            [e.kind for e in governor.trace_events],
+            [TraceEventKind.INTENT_APPROVED, TraceEventKind.INTENT_DENIED],
+        )
+
+    def test_it_emits_only_kinds_the_intent_loop_also_emits(self) -> None:
+        """The point of the whole change: one vocabulary, so one bridge and one
+        replay fold serve both paths. A kind only this path produced would need
+        its own handling everywhere downstream."""
+        governor = _governor()
+        approved = governor.evaluate("read_txns", {})
+        governor.register_output(approved, {"description": "PAY DE89370400440532013000"})
+        governor.evaluate("send_money", {"recipient": "PAY DE89370400440532013000"})
+        self.assertTrue(
+            {e.kind for e in governor.trace_events} <= INTENT_LOOP_VERDICT_KINDS,
+        )
+
+    def test_a_denial_carries_its_reason(self) -> None:
+        governor = _governor()
+        approved = governor.evaluate("read_txns", {})
+        governor.register_output(approved, {"description": "PAY DE89370400440532013000"})
+        governor.evaluate("send_money", {"recipient": "PAY DE89370400440532013000"})
+        denial = governor.trace_events[-1]
+        self.assertTrue(denial.reason)  # type: ignore[attr-defined]
+        self.assertEqual(denial.intent_kind, "tool_call")  # type: ignore[attr-defined]
+
+    def test_sequence_is_dense_and_ordered(self) -> None:
+        governor = _governor()
+        for _ in range(3):
+            governor.evaluate("read_txns", {})
+        self.assertEqual([e.sequence for e in governor.trace_events], [0, 1, 2])
+
+    def test_the_verdict_is_recorded_regardless_of_what_the_caller_does(self) -> None:
+        """The kernel reports what it DECIDED. Whether the caller then blocks is
+        the caller's business — a Lab ungoverned arm observes without enforcing,
+        and if the denial went unrecorded that arm would have no verdicts to
+        replay and nothing to compare against the governed one."""
+        governor = _governor()
+        approved = governor.evaluate("read_txns", {})
+        governor.register_output(approved, {"description": "PAY DE89370400440532013000"})
+        denied = governor.evaluate(
+            "send_money", {"recipient": "PAY DE89370400440532013000"},
+        )
+        # the caller ignores the verdict entirely and "executes" anyway
+        governor.register_output(denied, {"ok": True})
+        self.assertEqual(governor.trace_events[-1].kind, TraceEventKind.INTENT_DENIED)
+
+
+class TestDraining(unittest.TestCase):
+    def test_trace_events_is_a_copy(self) -> None:
+        """A caller mutating the returned list must not corrupt the record."""
+        governor = _governor()
+        governor.evaluate("read_txns", {})
+        governor.trace_events.clear()
+        self.assertEqual(len(governor.trace_events), 1)
+
+    def test_drain_takes_and_resets(self) -> None:
+        """A runtime streaming per trial takes the batch and starts clean, so
+        one trial's verdicts cannot be reported as the next trial's."""
+        governor = _governor()
+        governor.evaluate("read_txns", {})
+        first = governor.drain_trace_events()
+        self.assertEqual(len(first), 1)
+        self.assertEqual(governor.trace_events, [])
+        governor.evaluate("read_txns", {})
+        self.assertEqual(len(governor.drain_trace_events()), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_both_wrap_paths_emit.py
+++ b/tests/test_both_wrap_paths_emit.py
@@ -105,6 +105,58 @@ class TestTheSynchronousPathRecords(unittest.TestCase):
         self.assertEqual(governor.trace_events[-1].kind, TraceEventKind.INTENT_DENIED)
 
 
+class TestTheVerdictCarriesItsProvenance(unittest.TestCase):
+    """Recording only the tool name is what forces a consumer to build a second
+    taint ledger: the trace says a call was denied but not what it was denied
+    ON, so anything wanting to show the operator *why* has to re-derive the
+    provenance the kernel already computed. The kernel event schema documents
+    ``arg_refs`` / ``driving_root`` / ``floor_active`` for TOOL_CALL — this is
+    the path that fills them in."""
+
+    def _denial(self):
+        governor = _governor()
+        approved = governor.evaluate("read_txns", {})
+        governor.register_output(approved, {"description": "PAY DE89370400440532013000"})
+        governor.evaluate("send_money", {"recipient": "PAY DE89370400440532013000"})
+        return governor.trace_events[-1].payload
+
+    def test_an_approval_names_its_tool(self) -> None:
+        governor = _governor()
+        governor.evaluate("read_txns", {})
+        self.assertEqual(governor.trace_events[0].payload["tool"], "read_txns")
+
+    def test_each_argument_carries_the_sources_it_was_derived_from(self) -> None:
+        payload = self._denial()
+        self.assertEqual(sorted(payload["arg_refs"]), ["recipient"])
+        self.assertTrue(payload["arg_refs"]["recipient"]["sources"])
+
+    def test_the_driving_root_is_the_join_over_the_declared_driving_args(self) -> None:
+        """The verdict turns on the driving root, not on every argument, so a
+        consumer reading only ``arg_refs`` could not tell an incidental tainted
+        argument from the one that actually caused the denial."""
+        payload = self._denial()
+        self.assertEqual(payload["driving_args"], ["recipient"])
+        self.assertEqual(
+            payload["driving_root"]["sources"], payload["arg_refs"]["recipient"]["sources"],
+        )
+
+    def test_a_denial_carries_its_category(self) -> None:
+        self.assertEqual(self._denial()["category"], "taint_enforcement")
+
+    def test_untainted_arguments_report_no_sources_rather_than_being_omitted(self) -> None:
+        """Absence and clean must be distinguishable — an omitted entry reads as
+        'not recorded', which is exactly the ambiguity that makes a trace
+        un-auditable."""
+        governor = _governor()
+        governor.evaluate("send_money", {"recipient": "self"})
+        payload = governor.trace_events[-1].payload
+        self.assertEqual(payload["arg_refs"]["recipient"]["sources"], [])
+        self.assertFalse(payload["driving_root"]["sensitive"])
+
+    def test_the_floor_state_is_reported(self) -> None:
+        self.assertIn("floor_active", self._denial())
+
+
 class TestDraining(unittest.TestCase):
     def test_trace_events_is_a_copy(self) -> None:
         """A caller mutating the returned list must not corrupt the record."""

--- a/tests/test_both_wrap_paths_emit.py
+++ b/tests/test_both_wrap_paths_emit.py
@@ -25,10 +25,12 @@ from axor_core.contracts.trace import TraceEventKind
 from axor_core.governor import ToolCallGovernor
 
 # The kinds the IntentLoop emits for a tool-call verdict (intent_loop.py: the
-# approved/transformed emit, and _record_denial).
+# approved/transformed emit, and _record_denial) plus the source event it emits
+# when a read arms taint (_register_value_taint → _record_taint_propagated).
 INTENT_LOOP_VERDICT_KINDS = {
     TraceEventKind.INTENT_APPROVED,
     TraceEventKind.INTENT_DENIED,
+    TraceEventKind.TAINT_PROPAGATED,
 }
 
 
@@ -59,7 +61,10 @@ class TestTheSynchronousPathRecords(unittest.TestCase):
         self.assertFalse(denied.allowed)
         self.assertEqual(
             [e.kind for e in governor.trace_events],
-            [TraceEventKind.INTENT_APPROVED, TraceEventKind.INTENT_DENIED],
+            [TraceEventKind.INTENT_APPROVED,
+             # the read armed taint — the trace says WHERE it came from
+             TraceEventKind.TAINT_PROPAGATED,
+             TraceEventKind.INTENT_DENIED],
         )
 
     def test_it_emits_only_kinds_the_intent_loop_also_emits(self) -> None:

--- a/tests/test_both_wrap_paths_emit.py
+++ b/tests/test_both_wrap_paths_emit.py
@@ -156,6 +156,19 @@ class TestTheVerdictCarriesItsProvenance(unittest.TestCase):
     def test_the_floor_state_is_reported(self) -> None:
         self.assertIn("floor_active", self._denial())
 
+    def test_sources_are_declared_tokens_not_python_reprs(self) -> None:
+        """These tokens land in recorded governance artifacts that other
+        languages read and hash. `str()` on a `(str, Enum)` member yields
+        `TaintSource.WEB` — a Python implementation detail no Rust or TS
+        producer would ever emit for the same value."""
+        from axor_core.contracts.taint import TaintSource
+
+        declared = {s.value for s in TaintSource}
+        payload = self._denial()
+        for token in payload["driving_root"]["sources"]:
+            self.assertIn(token, declared, f"{token!r} is not a declared source value")
+        self.assertTrue(payload["driving_root"]["sources"])
+
 
 class TestDraining(unittest.TestCase):
     def test_trace_events_is_a_copy(self) -> None:

--- a/tests/test_gate_vocabulary.py
+++ b/tests/test_gate_vocabulary.py
@@ -1,0 +1,132 @@
+"""Every denial category the kernel can emit names a gate, and is recorded.
+
+Two failures motivated this file, and both were silent.
+
+1. Consumers kept private category→gate maps. axor-lab's was keyed on `ssrf`,
+   `consequence`, `positional`, `carrier` — names this kernel does not emit (it
+   emits `ssrf_gate`, `consequence_gate`, …). Seven of eleven categories fell
+   through unmapped, and the raw category landed in a field that only accepts a
+   gate name, producing traces that failed schema validation. Nothing caught it
+   because no test ever denied for those reasons end-to-end.
+
+2. The STRICT unclassified-tool denial returned directly instead of going
+   through the recording path, so the kernel's most security-relevant verdict —
+   an undeclared or renamed tool — left NO trace event. Replay saw an intent
+   with no decision; a consumer never learned anything was blocked.
+
+The guard against (1) recurring is that the mapping lives here and is checked
+against the categories actually present in the source. The guard against (2) is
+that a denial with no recorded event fails a test.
+"""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+from axor_core.contracts.trace import TraceEventKind
+from axor_core.governor import (
+    DENIAL_CATEGORIES,
+    GATE_OF_CATEGORY,
+    ToolCallGovernor,
+    gate_of,
+)
+
+SOURCE_ROOT = Path(__file__).resolve().parent.parent / "axor_core"
+
+# the nine-gate sequence a recorded verdict may name
+KNOWN_GATES = frozenset({
+    "capability", "consequence", "value_policies", "degradation", "ssrf",
+    "positional", "carrier", "taint_floor", "adjudicator", "message", "budget",
+})
+
+
+def _categories_in_source() -> set[str]:
+    """Every string literal passed as `category=` anywhere in the package.
+
+    Read from the AST rather than by running the kernel: a category only some
+    exotic configuration can reach is exactly the one a hand-written list
+    forgets, and it is the one whose trace turns out to be invalid in
+    production.
+    """
+    found: set[str] = set()
+    for path in SOURCE_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for keyword in node.keywords:
+                if keyword.arg == "category" and isinstance(keyword.value, ast.Constant):
+                    if isinstance(keyword.value.value, str):
+                        found.add(keyword.value.value)
+    return found
+
+
+class TestTheVocabularyIsComplete(unittest.TestCase):
+    def test_every_category_in_the_source_names_a_gate(self) -> None:
+        missing = _categories_in_source() - DENIAL_CATEGORIES
+        self.assertEqual(
+            missing, set(),
+            f"category/categories {sorted(missing)} can be emitted but name no gate — "
+            f"a consumer writing them into a trace would produce an invalid one",
+        )
+
+    def test_every_gate_named_is_a_real_gate(self) -> None:
+        unknown = set(GATE_OF_CATEGORY.values()) - KNOWN_GATES
+        self.assertEqual(unknown, set(), f"not gates: {sorted(unknown)}")
+
+    def test_an_unknown_category_raises_rather_than_passing_through(self) -> None:
+        """Passing the raw category through is what turned an unrecognised
+        denial into an invalid trace instead of a loud error."""
+        with self.assertRaises(ValueError) as ctx:
+            gate_of("something_new")
+        self.assertIn("unknown denial category", str(ctx.exception))
+
+    def test_known_categories_map(self) -> None:
+        self.assertEqual(gate_of("taint_enforcement"), "taint_floor")
+        self.assertEqual(gate_of("unclassified_tool"), "capability")
+
+
+class TestEveryDenialIsRecorded(unittest.TestCase):
+    def test_the_unclassified_tool_denial_emits_its_event(self) -> None:
+        """STRICT mode's refusal of an undeclared tool is the kernel's
+        fail-closed default. It returned without recording, so the one verdict
+        most worth auditing was the one that left no evidence."""
+        governor = ToolCallGovernor(
+            untrusted_sources={"read"}, egress_sinks={"send"},
+            driving_args={"send": {"to"}}, require_tool_roles=True,
+        )
+        decision = governor.evaluate("mystery_tool", {})
+        self.assertFalse(decision.allowed)
+        self.assertEqual(decision.category, "unclassified_tool")
+        self.assertEqual(
+            [e.kind for e in governor.trace_events], [TraceEventKind.INTENT_DENIED],
+        )
+
+    def test_that_event_carries_its_category_and_reason(self) -> None:
+        governor = ToolCallGovernor(
+            untrusted_sources={"read"}, egress_sinks={"send"},
+            driving_args={"send": {"to"}}, require_tool_roles=True,
+        )
+        governor.evaluate("mystery_tool", {})
+        event = governor.trace_events[-1]
+        self.assertEqual(event.payload["category"], "unclassified_tool")
+        self.assertIn("no declared data-flow role", event.reason)  # type: ignore[attr-defined]
+        self.assertEqual(gate_of(event.payload["category"]), "capability")
+
+    def test_a_denied_call_never_leaves_the_trace_empty(self) -> None:
+        """The general invariant: whatever the kernel refuses, it records."""
+        governor = ToolCallGovernor(
+            untrusted_sources={"read"}, egress_sinks={"send"},
+            driving_args={"send": {"to"}}, require_tool_roles=True,
+        )
+        for tool, args in (("mystery_tool", {}), ("send", {"to": "x"})):
+            with self.subTest(tool=tool):
+                before = len(governor.trace_events)
+                governor.evaluate(tool, args)
+                self.assertGreater(len(governor.trace_events), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gate_vocabulary.py
+++ b/tests/test_gate_vocabulary.py
@@ -88,6 +88,34 @@ class TestTheVocabularyIsComplete(unittest.TestCase):
         self.assertEqual(gate_of("unclassified_tool"), "capability")
 
 
+class TestTheStreamingPathNamesItsGateToo(unittest.TestCase):
+    """A denial has to name the gate that produced it on BOTH wrapping paths.
+
+    The streaming path recorded a reason string and nothing else, so a consumer
+    writing `trace/v1` — whose `gate` field takes a gate name, not a reason —
+    had nothing to fill in. Every `_record_denial` site now passes a category,
+    and every one of those categories has to be in the closed set.
+    """
+
+    def _categories_passed_to_record_denial(self) -> set[str]:
+        import re
+
+        source = (SOURCE_ROOT / "node" / "intent_loop.py").read_text()
+        return set(re.findall(
+            r"_record_denial\([^)]*?envelope,\s*[\"'](\w+)[\"']", source, re.S,
+        ))
+
+    def test_every_denial_site_names_a_known_category(self) -> None:
+        used = self._categories_passed_to_record_denial()
+        self.assertTrue(used, "no categorised denial site found — did the call shape change?")
+        self.assertEqual(used - DENIAL_CATEGORIES, set())
+
+    def test_each_maps_to_a_gate(self) -> None:
+        for category in self._categories_passed_to_record_denial():
+            with self.subTest(category=category):
+                self.assertIn(gate_of(category), KNOWN_GATES)
+
+
 class TestEveryDenialIsRecorded(unittest.TestCase):
     def test_the_unclassified_tool_denial_emits_its_event(self) -> None:
         """STRICT mode's refusal of an undeclared tool is the kernel's

--- a/tests/test_governor_payload_survives_replay.py
+++ b/tests/test_governor_payload_survives_replay.py
@@ -4,25 +4,30 @@
 it. Nothing checked that the payload the governor actually emits is one that
 fold can read — the two sides were only ever compared by reading prose.
 
-They disagreed. The schema's ``arg_refs`` is ``{arg: value_ref}``: opaque value
-IDS that `_derive_driving_root` looks up in `state.tainted_refs` and that
-`subgraph` walks as edges. The governor filled it with a nested per-argument
-provenance dict, so the fold did
+They disagreed twice, in opposite directions.
 
-    for ref in arg_refs.values():
-        if ref in state.excised_refs:
+First the governor filled ``arg_refs`` with a nested per-argument provenance
+dict. ``arg_refs`` is ``{arg: value_ref}`` — opaque value IDS that
+`_derive_driving_root` looks up in `state.tainted_refs` and that `subgraph`
+walks as edges — so the fold did ``if ref in state.excised_refs`` on a dict and
+died with `TypeError: unhashable type: 'dict'`. The per-argument breakdown moved
+to ``arg_provenance``, where it belongs.
 
-on a dict and died with `TypeError: unhashable type: 'dict'`. Every recorded
-verdict from the synchronous path was unreplayable, and `subgraph` would have
-stringified those dicts into nonsense node ids.
+Then the governor recorded no refs at all, and that was the deeper gap: it has
+no ref vocabulary of its own (it derives taint from content, not from minted
+ids), so a recorded verdict named a tool and a root and nothing that BOUND the
+denied argument to the read that tainted it. Replay coped — it falls back to
+``driving_root`` — but every consumer reasoning over the value graph got an
+empty graph, and the Control Plane's incident converter, which binds a sink's
+driving arg through ``arg_refs``, could not reproduce a single recorded DENY and
+refused whole runs.
 
-The governor has no value-ref vocabulary — it derives taint from content, not
-from minted ids — so it leaves `arg_refs` alone and records `driving_root`,
-which is exactly the fallback `_derive_driving_root` takes and which is what the
-verdict turned on. The per-argument breakdown lives under `arg_provenance`.
+So the governor now mints refs (`policy.provenance.ValueRefLedger`) with the
+SAME content derivation the gates decide on, records a source event per arming
+read, and binds them in ``arg_refs``.
 
-So these tests do not read a docstring. They take the bytes the governor emits
-and put them through the real fold.
+These tests do not read a docstring. They take the bytes the governor emits and
+put them through the real fold.
 """
 
 from __future__ import annotations
@@ -41,8 +46,8 @@ from axor_core.kernel.replay import (
 TAINTED = "PAY DE89370400440532013000"
 
 
-def _payloads() -> list[dict]:
-    """A real approve-then-deny session's recorded payloads."""
+def _session() -> ToolCallGovernor:
+    """A real approve-then-deny session on the real kernel."""
     governor = ToolCallGovernor(
         untrusted_sources={"read"}, egress_sinks={"send"},
         driving_args={"send": ["to"]},
@@ -50,7 +55,24 @@ def _payloads() -> list[dict]:
     approved = governor.evaluate("read", {})
     governor.register_output(approved, {"description": TAINTED})
     governor.evaluate("send", {"to": TAINTED})
-    return [dict(e.payload) for e in governor.trace_events]
+    return governor
+
+
+def _payloads() -> list[dict]:
+    return [dict(e.payload) for e in _session().trace_events]
+
+
+def _fold_state() -> GovernanceState:
+    """The state a consumer folding this session's SOURCE events arrives at —
+    what `kernel.replay` builds from the TOOL_RESULT branch."""
+    state = GovernanceState()
+    for event in _session().trace_events:
+        if event.kind is not TraceEventKind.TAINT_PROPAGATED:
+            continue
+        state.tainted_refs[str(event.payload["value_ref"])] = root_from_payload(
+            event.payload["root"],
+        )
+    return state
 
 
 class TestTheFoldCanReadWhatTheGovernorWrote(unittest.TestCase):
@@ -58,13 +80,13 @@ class TestTheFoldCanReadWhatTheGovernorWrote(unittest.TestCase):
         """It raised. `TypeError: unhashable type: 'dict'`, on every call."""
         for payload in _payloads():
             with self.subTest(tool=payload.get("tool")):
-                _derive_driving_root(payload, GovernanceState(), KernelConfig())
+                _derive_driving_root(payload, _fold_state(), KernelConfig())
 
     def test_the_derived_root_carries_the_taint_the_governor_found(self) -> None:
         """Not merely 'does not crash': the fold has to arrive at the same taint
         the governor denied on, or a replay silently re-decides on nothing."""
         denial = _payloads()[-1]
-        root = _derive_driving_root(denial, GovernanceState(), KernelConfig())
+        root = _derive_driving_root(denial, _fold_state(), KernelConfig())
         self.assertTrue(root.sources, "the fold derived a clean root for a tainted call")
 
     def test_driving_root_round_trips_through_root_from_payload(self) -> None:
@@ -76,22 +98,45 @@ class TestTheFoldCanReadWhatTheGovernorWrote(unittest.TestCase):
         self.assertTrue(root.sources)
 
 
-class TestArgRefsIsLeftForRefs(unittest.TestCase):
-    def test_the_governor_does_not_populate_arg_refs(self) -> None:
-        """It mints no value ids, so anything it put there would be a lie the
-        fold and the subgraph both act on."""
-        for payload in _payloads():
-            with self.subTest(tool=payload.get("tool")):
-                self.assertNotIn("arg_refs", payload)
+class TestArgRefsBindTheSinkToItsSource(unittest.TestCase):
+    """The binding a consumer needs to answer "denied on WHAT value" without
+    re-deriving provenance from raw arguments."""
 
-    def test_the_per_argument_breakdown_is_under_its_own_key(self) -> None:
+    def test_the_denied_argument_names_the_ref_the_read_minted(self) -> None:
+        events = _session().trace_events
+        source = next(
+            e for e in events if e.kind is TraceEventKind.TAINT_PROPAGATED
+        )
+        denial = events[-1]
+        self.assertEqual(
+            denial.payload["arg_refs"]["to"], source.payload["value_ref"],
+        )
+
+    def test_the_per_argument_breakdown_keeps_its_own_key(self) -> None:
+        """`arg_provenance` is a taint SUMMARY; `arg_refs` is a graph edge. They
+        are not interchangeable and filling one with the other's shape is what
+        crashed the fold."""
         denial = _payloads()[-1]
         self.assertIn("to", denial["arg_provenance"])
         self.assertTrue(denial["arg_provenance"]["to"]["sources"])
+        self.assertIsInstance(denial["arg_refs"]["to"], str)
+
+    def test_a_clean_argument_is_bound_to_no_ref(self) -> None:
+        """A ref claims 'this argument carries that value'. Minting one for an
+        argument the ledger does not derive from any registered read would be a
+        graph edge that does not exist."""
+        governor = ToolCallGovernor(
+            untrusted_sources={"read"}, egress_sinks={"send"},
+            driving_args={"send": ["to"]},
+        )
+        approved = governor.evaluate("read", {})
+        governor.register_output(approved, {"description": TAINTED})
+        governor.evaluate("send", {"to": "my-own-account"})
+        self.assertNotIn("arg_refs", governor.trace_events[-1].payload)
 
     def test_a_real_arg_refs_still_takes_precedence_in_the_fold(self) -> None:
-        """The documented path is unchanged: a producer that DOES mint refs gets
-        them resolved against the session's tainted values."""
+        """The documented path is unchanged: refs are resolved against the
+        session's tainted values, not against the recorded root."""
         from axor_core.contracts.taint import TaintSource
         from axor_core.taint.causal_root import CausalRoot
 
@@ -104,17 +149,38 @@ class TestArgRefsIsLeftForRefs(unittest.TestCase):
         self.assertIn(TaintSource.WEB, root.sources)
 
 
+class TestAnUnresolvableRefDoesNotFailOpen(unittest.TestCase):
+    """The failure mode minting refs introduces, and the reason the fold has a
+    fallback. Every ref is a promise that some earlier event registered it; a
+    fold that never saw that event has NO information, and the pre-existing
+    branch answered "no information" with "clean" — turning a recorded DENY into
+    an ALLOW on a truncated trace."""
+
+    def test_a_denial_whose_source_event_is_missing_stays_tainted(self) -> None:
+        denial = _payloads()[-1]
+        # the same payload, folded WITHOUT the source event
+        root = _derive_driving_root(denial, GovernanceState(), KernelConfig())
+        self.assertTrue(
+            root.sources,
+            "an unresolvable ref re-decided a tainted call as clean",
+        )
+
+    def test_excision_still_yields_a_clean_root(self) -> None:
+        """Excision is the one case where 'no root' is the ANSWER, not missing
+        data — the operator removed that value's future influence (spec 8.2.1),
+        so falling back to the recorded root would undo the counterfactual."""
+        denial = _payloads()[-1]
+        state = _fold_state()
+        state.excised_refs.update(denial["arg_refs"].values())
+        root = _derive_driving_root(denial, state, KernelConfig())
+        self.assertFalse(root.sources)
+        self.assertFalse(root.sensitive)
+
+
 class TestBothPathsStillRecordAlike(unittest.TestCase):
     def test_the_denial_still_names_its_gate_and_kind(self) -> None:
-        """The rest of the payload is unaffected by moving the breakdown."""
-        governor = ToolCallGovernor(
-            untrusted_sources={"read"}, egress_sinks={"send"},
-            driving_args={"send": ["to"]},
-        )
-        approved = governor.evaluate("read", {})
-        governor.register_output(approved, {"description": TAINTED})
-        governor.evaluate("send", {"to": TAINTED})
-        denial = governor.trace_events[-1]
+        """The rest of the payload is unaffected by the ref work."""
+        denial = _session().trace_events[-1]
         self.assertEqual(denial.kind, TraceEventKind.INTENT_DENIED)
         # whichever gate fires first, the category must be one `gate_of` knows —
         # not a guess at WHICH gate, which is the kernel's business

--- a/tests/test_governor_payload_survives_replay.py
+++ b/tests/test_governor_payload_survives_replay.py
@@ -1,0 +1,128 @@
+"""What the governor records must survive the fold that consumes it.
+
+`kernel/events.py` documents the TOOL_CALL payload and `kernel/replay.py` folds
+it. Nothing checked that the payload the governor actually emits is one that
+fold can read — the two sides were only ever compared by reading prose.
+
+They disagreed. The schema's ``arg_refs`` is ``{arg: value_ref}``: opaque value
+IDS that `_derive_driving_root` looks up in `state.tainted_refs` and that
+`subgraph` walks as edges. The governor filled it with a nested per-argument
+provenance dict, so the fold did
+
+    for ref in arg_refs.values():
+        if ref in state.excised_refs:
+
+on a dict and died with `TypeError: unhashable type: 'dict'`. Every recorded
+verdict from the synchronous path was unreplayable, and `subgraph` would have
+stringified those dicts into nonsense node ids.
+
+The governor has no value-ref vocabulary — it derives taint from content, not
+from minted ids — so it leaves `arg_refs` alone and records `driving_root`,
+which is exactly the fallback `_derive_driving_root` takes and which is what the
+verdict turned on. The per-argument breakdown lives under `arg_provenance`.
+
+So these tests do not read a docstring. They take the bytes the governor emits
+and put them through the real fold.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from axor_core.contracts.trace import TraceEventKind
+from axor_core.governor import ToolCallGovernor
+from axor_core.kernel.replay import (
+    GovernanceState,
+    KernelConfig,
+    _derive_driving_root,
+    root_from_payload,
+)
+
+TAINTED = "PAY DE89370400440532013000"
+
+
+def _payloads() -> list[dict]:
+    """A real approve-then-deny session's recorded payloads."""
+    governor = ToolCallGovernor(
+        untrusted_sources={"read"}, egress_sinks={"send"},
+        driving_args={"send": ["to"]},
+    )
+    approved = governor.evaluate("read", {})
+    governor.register_output(approved, {"description": TAINTED})
+    governor.evaluate("send", {"to": TAINTED})
+    return [dict(e.payload) for e in governor.trace_events]
+
+
+class TestTheFoldCanReadWhatTheGovernorWrote(unittest.TestCase):
+    def test_deriving_the_driving_root_does_not_raise(self) -> None:
+        """It raised. `TypeError: unhashable type: 'dict'`, on every call."""
+        for payload in _payloads():
+            with self.subTest(tool=payload.get("tool")):
+                _derive_driving_root(payload, GovernanceState(), KernelConfig())
+
+    def test_the_derived_root_carries_the_taint_the_governor_found(self) -> None:
+        """Not merely 'does not crash': the fold has to arrive at the same taint
+        the governor denied on, or a replay silently re-decides on nothing."""
+        denial = _payloads()[-1]
+        root = _derive_driving_root(denial, GovernanceState(), KernelConfig())
+        self.assertTrue(root.sources, "the fold derived a clean root for a tainted call")
+
+    def test_driving_root_round_trips_through_root_from_payload(self) -> None:
+        """`root_from_payload` builds `TaintSource(s)` from each token, so a
+        token that is not a declared enum VALUE raises here — which is why the
+        payload records `web`, not `TaintSource.WEB`."""
+        denial = _payloads()[-1]
+        root = root_from_payload(denial["driving_root"])
+        self.assertTrue(root.sources)
+
+
+class TestArgRefsIsLeftForRefs(unittest.TestCase):
+    def test_the_governor_does_not_populate_arg_refs(self) -> None:
+        """It mints no value ids, so anything it put there would be a lie the
+        fold and the subgraph both act on."""
+        for payload in _payloads():
+            with self.subTest(tool=payload.get("tool")):
+                self.assertNotIn("arg_refs", payload)
+
+    def test_the_per_argument_breakdown_is_under_its_own_key(self) -> None:
+        denial = _payloads()[-1]
+        self.assertIn("to", denial["arg_provenance"])
+        self.assertTrue(denial["arg_provenance"]["to"]["sources"])
+
+    def test_a_real_arg_refs_still_takes_precedence_in_the_fold(self) -> None:
+        """The documented path is unchanged: a producer that DOES mint refs gets
+        them resolved against the session's tainted values."""
+        from axor_core.contracts.taint import TaintSource
+        from axor_core.taint.causal_root import CausalRoot
+
+        state = GovernanceState()
+        state.tainted_refs["v1"] = CausalRoot.external_read(TaintSource.WEB)
+        root = _derive_driving_root(
+            {"arg_refs": {"to": "v1"}, "driving_root": {"sources": [], "sensitive": False}},
+            state, KernelConfig(),
+        )
+        self.assertIn(TaintSource.WEB, root.sources)
+
+
+class TestBothPathsStillRecordAlike(unittest.TestCase):
+    def test_the_denial_still_names_its_gate_and_kind(self) -> None:
+        """The rest of the payload is unaffected by moving the breakdown."""
+        governor = ToolCallGovernor(
+            untrusted_sources={"read"}, egress_sinks={"send"},
+            driving_args={"send": ["to"]},
+        )
+        approved = governor.evaluate("read", {})
+        governor.register_output(approved, {"description": TAINTED})
+        governor.evaluate("send", {"to": TAINTED})
+        denial = governor.trace_events[-1]
+        self.assertEqual(denial.kind, TraceEventKind.INTENT_DENIED)
+        # whichever gate fires first, the category must be one `gate_of` knows —
+        # not a guess at WHICH gate, which is the kernel's business
+        from axor_core.governor import DENIAL_CATEGORIES
+
+        self.assertIn(denial.payload["category"], DENIAL_CATEGORIES)
+        self.assertEqual(denial.payload["driving_args"], ["to"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wrap_paths_record_alike.py
+++ b/tests/test_wrap_paths_record_alike.py
@@ -73,6 +73,10 @@ def _verdicts(events):
     ]
 
 
+def _sources(events):
+    return [e for e in events if e.kind is TraceEventKind.TAINT_PROPAGATED]
+
+
 def _path_b():
     """The synchronous path: the framework owns the loop."""
     governor = ToolCallGovernor(
@@ -81,7 +85,7 @@ def _path_b():
     approved = governor.evaluate("read", {})
     governor.register_output(approved, {"description": TAINTED})
     governor.evaluate("write", {"recipient": TAINTED})
-    return _verdicts(governor.trace_events)
+    return governor.trace_events
 
 
 async def _path_a(make_envelope, _focused):
@@ -113,12 +117,12 @@ async def _path_a(make_envelope, _focused):
     )
     async for _ in loop.run(_stream(), make_envelope(policy=_focused)):
         pass
-    return _verdicts(events)
+    return events
 
 
 class TestTheSynchronousPathRecordsProvenance:
     def test_every_verdict_carries_the_full_shape(self) -> None:
-        for event in _path_b():
+        for event in _verdicts(_path_b()):
             assert PROVENANCE_KEYS <= set(event.payload), event.payload
 
 
@@ -127,7 +131,7 @@ class TestTheStreamingPathRecordsProvenance:
     async def test_every_verdict_carries_the_full_shape(
         self, make_envelope, focused_policy,
     ) -> None:
-        verdicts = await _path_a(make_envelope, focused_policy)
+        verdicts = _verdicts(await _path_a(make_envelope, focused_policy))
         assert verdicts, "the loop recorded no verdict at all"
         for event in verdicts:
             assert PROVENANCE_KEYS <= set(event.payload), event.payload
@@ -139,7 +143,7 @@ class TestTheStreamingPathRecordsProvenance:
         kernel refused and never what it refused over — so an operator asking
         'why' got the reason string and nothing to anchor it to."""
         denials = [
-            e for e in await _path_a(make_envelope, focused_policy)
+            e for e in _verdicts(await _path_a(make_envelope, focused_policy))
             if e.kind is TraceEventKind.INTENT_DENIED
         ]
         assert denials, "the tainted egress was not denied"
@@ -158,15 +162,37 @@ class TestBothPathsAgree:
         """The property the whole design rests on: a downstream consumer cannot
         tell which entry point produced the record, so one bridge and one replay
         fold serve both."""
-        a = await _path_a(make_envelope, focused_policy)
-        b = _path_b()
+        a = _verdicts(await _path_a(make_envelope, focused_policy))
+        b = _verdicts(_path_b())
         assert [e.kind for e in a] == [e.kind for e in b]
         for ea, eb in zip(a, b):
             assert {k: ea.payload[k] for k in PROVENANCE_KEYS} == \
                    {k: eb.payload[k] for k in PROVENANCE_KEYS}
 
     async def test_both_deny_the_same_call(self, make_envelope, focused_policy) -> None:
-        a = await _path_a(make_envelope, focused_policy)
-        b = _path_b()
+        a = _verdicts(await _path_a(make_envelope, focused_policy))
+        b = _verdicts(_path_b())
         assert [e.kind is TraceEventKind.INTENT_DENIED for e in a] == \
                [e.kind is TraceEventKind.INTENT_DENIED for e in b] == [False, True]
+
+    async def test_both_record_the_same_source_event(
+        self, make_envelope, focused_policy,
+    ) -> None:
+        """The event that says WHERE the taint entered. Neither path emitted one,
+        so a trace was a list of verdicts with no origin: nothing to fold into
+        `tainted_refs`, so the `arg_refs` on the denial resolved to nothing, and
+        the Control Plane refused the run for having no untrusted source."""
+        a = _sources(await _path_a(make_envelope, focused_policy))
+        b = _sources(_path_b())
+        assert len(a) == len(b) == 1, (len(a), len(b))
+        assert a[0].payload == b[0].payload
+        assert a[0].payload["root"]["sources"] == ["web"]
+
+    async def test_the_denied_argument_binds_to_that_source_on_both_paths(
+        self, make_envelope, focused_policy,
+    ) -> None:
+        for events in (await _path_a(make_envelope, focused_policy), _path_b()):
+            source = _sources(events)[0]
+            denial = _verdicts(events)[-1]
+            assert denial.payload["arg_refs"]["recipient"] == \
+                source.payload["value_ref"]

--- a/tests/test_wrap_paths_record_alike.py
+++ b/tests/test_wrap_paths_record_alike.py
@@ -1,0 +1,172 @@
+"""The two ways of wrapping an agent record the SAME thing.
+
+`ToolCallGovernor` and `IntentLoop` are not competing designs — they are two
+entry points to one kernel, chosen by who owns the agent loop. The framework
+owning it gets the synchronous governor; the kernel owning it gets the streaming
+loop. A consumer downstream should not be able to tell which was used, because
+the verdict and the provenance it turned on are the same verdict and the same
+provenance.
+
+They did not record alike. The governor recorded `payload={"tool": name}` and
+the loop recorded the same, with a denial recording no payload at all. Each had
+computed the per-argument taint roots, the driving-arg join and the floor state
+to REACH its verdict, and each threw all of it away — so anything wanting to
+show an operator *why* a call was refused had to re-derive provenance from raw
+arguments. That is how a second taint ledger gets built downstream, and it is
+what happened: axor-lab grew one.
+
+Both now call one shared builder (`policy.provenance.call_payload`). This file
+drives the real kernel down both paths with the same attack and asserts the
+recorded payloads are equal — the property that lets ONE bridge and ONE replay
+fold serve both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from typing import Any
+
+from axor_core.capability.executor import CapabilityExecutor, ToolHandler
+from axor_core.contracts.result import ExecutorEvent, ExecutorEventKind
+from axor_core.contracts.trace import TraceEventKind
+from axor_core.governor import ToolCallGovernor
+
+
+class _Handler(ToolHandler):
+    def __init__(self, name: str, result: Any) -> None:
+        self._name, self._result = name, result
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    async def execute(self, args: dict[str, Any]) -> Any:
+        return self._result
+
+
+def _executor() -> CapabilityExecutor:
+    """BOTH tools registered. An unregistered tool is refused by the capability
+    gate before the taint cascade runs, which would compare a capability denial
+    here against a taint denial there."""
+    ex = CapabilityExecutor()
+    ex.register(_Handler("read", {"description": TAINTED}))
+    ex.register(_Handler("write", {"ok": True}))
+    return ex
+
+# one deployment taxonomy, used by both paths
+# `read` / `write` because the stock test policy already admits those
+# capabilities. The taxonomy below is what makes them a taint SOURCE and an
+# egress SINK — the tool names themselves carry no meaning to the kernel.
+UNTRUSTED = {"read"}
+EGRESS = {"write"}
+DRIVING = {"write": ["recipient"]}
+TAINTED = "PAY DE89370400440532013000"
+
+PROVENANCE_KEYS = {"tool", "arg_refs", "driving_args", "driving_root", "floor_active"}
+
+
+def _verdicts(events):
+    return [
+        e for e in events
+        if e.kind in (TraceEventKind.INTENT_APPROVED, TraceEventKind.INTENT_DENIED)
+    ]
+
+
+def _path_b():
+    """The synchronous path: the framework owns the loop."""
+    governor = ToolCallGovernor(
+        untrusted_sources=UNTRUSTED, egress_sinks=EGRESS, driving_args=DRIVING,
+    )
+    approved = governor.evaluate("read", {})
+    governor.register_output(approved, {"description": TAINTED})
+    governor.evaluate("write", {"recipient": TAINTED})
+    return _verdicts(governor.trace_events)
+
+
+async def _path_a(make_envelope, _focused):
+    """The streaming path: the kernel owns the loop."""
+    from axor_core.node.intent_loop import IntentLoop
+
+    async def _stream():
+        yield ExecutorEvent(
+            kind=ExecutorEventKind.TOOL_USE,
+            payload={"tool": "read", "args": {}, "tool_use_id": "t1"},
+            node_id="node_test_root",
+        )
+        yield ExecutorEvent(
+            kind=ExecutorEventKind.TOOL_USE,
+            payload={"tool": "write", "args": {"recipient": TAINTED},
+                     "tool_use_id": "t2"},
+            node_id="node_test_root",
+        )
+        yield ExecutorEvent(
+            kind=ExecutorEventKind.STOP,
+            payload={"usage": {"input_tokens": 1, "output_tokens": 1, "tool_tokens": 0}},
+            node_id="node_test_root",
+        )
+
+    events: list = []
+    loop = IntentLoop(
+        capability_executor=_executor(), trace_events=events,
+        untrusted_sources=UNTRUSTED, egress_sinks=EGRESS, driving_args=DRIVING,
+    )
+    async for _ in loop.run(_stream(), make_envelope(policy=_focused)):
+        pass
+    return _verdicts(events)
+
+
+class TestTheSynchronousPathRecordsProvenance:
+    def test_every_verdict_carries_the_full_shape(self) -> None:
+        for event in _path_b():
+            assert PROVENANCE_KEYS <= set(event.payload), event.payload
+
+
+@pytest.mark.asyncio
+class TestTheStreamingPathRecordsProvenance:
+    async def test_every_verdict_carries_the_full_shape(
+        self, make_envelope, focused_policy,
+    ) -> None:
+        verdicts = await _path_a(make_envelope, focused_policy)
+        assert verdicts, "the loop recorded no verdict at all"
+        for event in verdicts:
+            assert PROVENANCE_KEYS <= set(event.payload), event.payload
+
+    async def test_a_denial_carries_what_it_was_denied_ON(
+        self, make_envelope, focused_policy,
+    ) -> None:
+        """A denial used to record NO payload. A consumer could see THAT the
+        kernel refused and never what it refused over — so an operator asking
+        'why' got the reason string and nothing to anchor it to."""
+        denials = [
+            e for e in await _path_a(make_envelope, focused_policy)
+            if e.kind is TraceEventKind.INTENT_DENIED
+        ]
+        assert denials, "the tainted egress was not denied"
+        payload = denials[0].payload
+        assert payload["driving_args"] == ["recipient"]
+        assert payload["arg_refs"]["recipient"]["sources"]
+        assert payload["driving_root"]["sources"] == \
+            payload["arg_refs"]["recipient"]["sources"]
+
+
+@pytest.mark.asyncio
+class TestBothPathsAgree:
+    async def test_the_recorded_provenance_is_identical(
+        self, make_envelope, focused_policy,
+    ) -> None:
+        """The property the whole design rests on: a downstream consumer cannot
+        tell which entry point produced the record, so one bridge and one replay
+        fold serve both."""
+        a = await _path_a(make_envelope, focused_policy)
+        b = _path_b()
+        assert [e.kind for e in a] == [e.kind for e in b]
+        for ea, eb in zip(a, b):
+            assert {k: ea.payload[k] for k in PROVENANCE_KEYS} == \
+                   {k: eb.payload[k] for k in PROVENANCE_KEYS}
+
+    async def test_both_deny_the_same_call(self, make_envelope, focused_policy) -> None:
+        a = await _path_a(make_envelope, focused_policy)
+        b = _path_b()
+        assert [e.kind is TraceEventKind.INTENT_DENIED for e in a] == \
+               [e.kind is TraceEventKind.INTENT_DENIED for e in b] == [False, True]

--- a/tests/test_wrap_paths_record_alike.py
+++ b/tests/test_wrap_paths_record_alike.py
@@ -63,7 +63,7 @@ EGRESS = {"write"}
 DRIVING = {"write": ["recipient"]}
 TAINTED = "PAY DE89370400440532013000"
 
-PROVENANCE_KEYS = {"tool", "arg_refs", "driving_args", "driving_root", "floor_active"}
+PROVENANCE_KEYS = {"tool", "arg_provenance", "driving_args", "driving_root", "floor_active"}
 
 
 def _verdicts(events):
@@ -145,9 +145,9 @@ class TestTheStreamingPathRecordsProvenance:
         assert denials, "the tainted egress was not denied"
         payload = denials[0].payload
         assert payload["driving_args"] == ["recipient"]
-        assert payload["arg_refs"]["recipient"]["sources"]
+        assert payload["arg_provenance"]["recipient"]["sources"]
         assert payload["driving_root"]["sources"] == \
-            payload["arg_refs"]["recipient"]["sources"]
+            payload["arg_provenance"]["recipient"]["sources"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Makes a governor verdict replayable and self-explaining.

- Record the same `TraceEvents` the IntentLoop records, and the provenance the verdict was reached on — a recorded verdict that no consumer could replay is now replayable.
- Name the gate behind each denial (in the governor and in the IntentLoop denial), and record every denial.
- Taint sources are declared tokens, not Python reprs; `arg_refs` means value refs (filled with dicts, not reprs).
- One payload builder for provenance shared by both ways of wrapping an agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jooSiBfx6FvnQx48QkkB3

---
_Generated by [Claude Code](https://claude.ai/code/session_014jooSiBfx6FvnQx48QkkB3)_