### PR TITLE
Release 0.10.2 and fan the publish trigger out to Lab and control-plane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,8 @@ jobs:
           VERSION="${VERSION#v}"   # strip leading "v" so pip can use it directly
           PAYLOAD="{\"event_type\":\"axor-core-published\",\"client_payload\":{\"version\":\"${VERSION}\"}}"
           for REPO in \
+            Bucha11/axor-lab \
+            Bucha11/axor-control-plane \
             Bucha11/axor-sentinel \
             Bucha11/axor-claude \
             Bucha11/axor-cli \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
           for REPO in \
             Bucha11/axor-lab \
             Bucha11/axor-control-plane \
+            Bucha11/axor-wrap \
             Bucha11/axor-sentinel \
             Bucha11/axor-claude \
             Bucha11/axor-cli \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axor-core"
-version = "0.10.0"
+version = "0.10.2"
 description = "Provider-agnostic governance kernel for agent systems"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Follow-up to #26 (merged): cut the release the downstream consumers pin, and make a publish rebuild them.

- **Release 0.10.2** — bumps the version so the surface added in #26 (`axor_core.governor.gate_of`, `ToolCallGovernor.trace_events`) ships under a resolvable release. axor-lab (`>=0.10.2`) and axor-wrap depend on it; their CI is red until 0.10.2 is on PyPI. `__version__` derives from package metadata, so the version field is the only change. Tag `v0.10.2` to trigger the PyPI publish job.
- **Fan the publish trigger out to Lab and the control-plane** — both depend on the kernel but were missing from the `Trigger downstream rebuilds` list, so a release did not re-run their CI. Added `Bucha11/axor-lab` and `Bucha11/axor-control-plane`; they now listen on the `axor-core-published` `repository_dispatch`, so publishing a new axor-core rebuilds them automatically.

Merging + tagging this publishes 0.10.2 and unblocks axor-lab / axor-wrap CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jooSiBfx6FvnQx48QkkB3

---
_Generated by [Claude Code](https://claude.ai/code/session_014jooSiBfx6FvnQx48QkkB3)_