### PR TITLE
0.11.0: own the schemas that cross a product boundary, and the engine that reads them

### DIFF
--- a/axor_core/contracts/schemas/__init__.py
+++ b/axor_core/contracts/schemas/__init__.py
@@ -1,0 +1,68 @@
+"""The contract schemas, owned by the kernel and shipped inside it.
+
+Three artifacts cross product boundaries in this ecosystem: a recorded trace, a
+tool manifest, and the Lab → Control Plane deploy package. Until now none of them
+had a single owner. `trace` and `tool-manifest` were documented as
+"axor-core-owned" while the only real definitions lived downstream in the Lab —
+which kept a directory literally named `_shared_from_axor_core` holding narrower
+stubs of files this package did not have. `cp-deploy` had no schema anywhere: its
+producer and consumer were written independently in two repositories, and had
+already drifted apart without anyone noticing.
+
+They live here because this package is the one dependency every consumer already
+has. `axor_core.contracts` has always held the shared vocabulary as Python types;
+these are the same vocabulary in the serialization that crosses a process.
+
+Validation uses the subset validator next door — not the `jsonschema` package.
+The schemas are written to the subset it implements, and this package stays
+dependency-free.
+"""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from typing import Any
+
+__all__ = ["SCHEMA_NAMES", "SchemaInvalid", "load", "validate"]
+
+SCHEMA_NAMES = ("trace", "tool-manifest", "cp-deploy")
+
+
+class SchemaInvalid(ValueError):
+    """An artifact failed validation. `errors` lists every problem, not the first.
+
+    A validator that stops at the first error makes a caller fix one field, run
+    again, and find the next — the contract these schemas describe is that a
+    rejection is complete.
+    """
+
+    def __init__(self, schema_name: str, errors: list[str]) -> None:
+        self.schema_name = schema_name
+        self.errors = list(errors)
+        super().__init__(f"{schema_name}: " + "; ".join(errors))
+
+
+def load(name: str) -> dict[str, Any]:
+    """One schema by name, e.g. ``load("cp-deploy")``."""
+    if name not in SCHEMA_NAMES:
+        raise KeyError(f"unknown schema {name!r}; have {list(SCHEMA_NAMES)}")
+    text = (
+        resources.files(__package__)
+        .joinpath(f"{name}.schema.json")
+        .read_text("utf-8")
+    )
+    return json.loads(text)
+
+
+def validate(name: str, document: Any) -> list[str]:  # noqa: ANN401 - untrusted input
+    """Every way `document` violates schema `name`, or an empty list.
+
+    Returns rather than raises, so a caller can merge these into its own reason
+    list — a consumer of one of these artifacts almost always has checks the
+    schema cannot express (a storage key's width, a hash recomputed over the
+    payload) and must report them together.
+    """
+    from ._subset_validator import validate_against  # noqa: PLC0415
+
+    return validate_against(document, name, {n: load(n) for n in SCHEMA_NAMES})

--- a/axor_core/contracts/schemas/__init__.py
+++ b/axor_core/contracts/schemas/__init__.py
@@ -29,7 +29,16 @@ import json
 from importlib import resources
 from typing import Any
 
-__all__ = ["SCHEMA_NAMES", "SchemaInvalid", "load", "validate"]
+from ._subset_validator import validate_against
+
+__all__ = [
+    "SCHEMA_NAMES",
+    "SchemaInvalid",
+    "kernel_schemas",
+    "load",
+    "validate",
+    "validate_against",
+]
 
 SCHEMA_NAMES = ("trace", "tool-manifest", "predicate", "cp-deploy")
 
@@ -68,6 +77,15 @@ def validate(name: str, document: Any) -> list[str]:
     schema cannot express (a storage key's width, a hash recomputed over the
     payload) and must report them together.
     """
-    from ._subset_validator import validate_against
+    return validate_against(document, name, kernel_schemas())
 
-    return validate_against(document, name, {n: load(n) for n in SCHEMA_NAMES})
+
+def kernel_schemas() -> dict[str, dict[str, Any]]:
+    """Every schema here, keyed by short name — the form `validate_against` takes.
+
+    A consumer with product-specific schemas of its own validates them all in
+    one dictionary, because they reference each other across files: a Lab
+    `condition` refs `predicate`, which a `tool-manifest` refs too. It merges
+    this over its own set rather than keeping copies of these three.
+    """
+    return {name: load(name) for name in SCHEMA_NAMES}

--- a/axor_core/contracts/schemas/__init__.py
+++ b/axor_core/contracts/schemas/__init__.py
@@ -9,6 +9,11 @@ stubs of files this package did not have. `cp-deploy` had no schema anywhere: it
 producer and consumer were written independently in two repositories, and had
 already drifted apart without anyone noticing.
 
+`predicate` is here for a narrower reason: a manifest's `effect.resolve[].when`
+is one, so a tool manifest is not a self-contained artifact without it, and a
+consumer validating a manifest that resolves its effect class from arguments
+would be told the reference is unknown and reject a valid manifest.
+
 They live here because this package is the one dependency every consumer already
 has. `axor_core.contracts` has always held the shared vocabulary as Python types;
 these are the same vocabulary in the serialization that crosses a process.
@@ -26,7 +31,7 @@ from typing import Any
 
 __all__ = ["SCHEMA_NAMES", "SchemaInvalid", "load", "validate"]
 
-SCHEMA_NAMES = ("trace", "tool-manifest", "cp-deploy")
+SCHEMA_NAMES = ("trace", "tool-manifest", "predicate", "cp-deploy")
 
 
 class SchemaInvalid(ValueError):
@@ -55,7 +60,7 @@ def load(name: str) -> dict[str, Any]:
     return json.loads(text)
 
 
-def validate(name: str, document: Any) -> list[str]:  # noqa: ANN401 - untrusted input
+def validate(name: str, document: Any) -> list[str]:
     """Every way `document` violates schema `name`, or an empty list.
 
     Returns rather than raises, so a caller can merge these into its own reason
@@ -63,6 +68,6 @@ def validate(name: str, document: Any) -> list[str]:  # noqa: ANN401 - untrusted
     schema cannot express (a storage key's width, a hash recomputed over the
     payload) and must report them together.
     """
-    from ._subset_validator import validate_against  # noqa: PLC0415
+    from ._subset_validator import validate_against
 
     return validate_against(document, name, {n: load(n) for n in SCHEMA_NAMES})

--- a/axor_core/contracts/schemas/_subset_validator.py
+++ b/axor_core/contracts/schemas/_subset_validator.py
@@ -1,0 +1,192 @@
+"""JSON-Schema subset validator for the contract schemas.
+
+Supports the subset the contract schemas use: type / required / enum / const /
+pattern / min-maxLength / oneOf / anyOf / properties / additionalProperties /
+items / min-maxProperties / minimum, with local ``#/$defs/...`` and cross-schema
+``<name>.schema.json[#/$defs/...]`` references.
+
+Deliberately not the `jsonschema` package. This validator is part of the
+contract — the schemas are written to the subset it implements, and its
+semantics are what CI keeps green against the slice examples — and it keeps this
+package dependency-free, which is the posture every other optional feature here
+already takes.
+
+It lives in the kernel because the schemas do. It arrived from axor-lab, which
+wrote it and still validates its own product-specific artifacts with it; a
+generic engine had no business being owned by one consumer of the contracts it
+enforces, and two copies of a validator would have been the same mistake as two
+copies of a schema.
+"""
+
+from __future__ import annotations
+
+import re
+
+_TYPE_MAP: dict[str, type | tuple[type, ...]] = {
+    "object": dict,
+    "array": list,
+    "string": str,
+    "number": (int, float),
+    "integer": int,
+    "boolean": bool,
+}
+
+
+def validate_against(
+    obj: object,
+    schema_name: str,
+    schemas: dict[str, dict[str, object]],
+) -> list[str]:
+    """Validate ``obj`` against the named contract schema; return error list."""
+    errors: list[str] = []
+    schema = schemas[schema_name]
+    _check(obj, schema, schema_name, schema, schemas, errors)
+    return errors
+
+
+def _check(
+    node: object,
+    schema: dict[str, object],
+    path: str,
+    root: dict[str, object],
+    schemas: dict[str, dict[str, object]],
+    errors: list[str],
+) -> None:
+    resolved = _resolve_ref(schema, root, schemas, path, errors)
+    if resolved is None:
+        return
+    schema, root = resolved
+
+    if "const" in schema and node != schema["const"]:
+        errors.append(f"{path}: const mismatch: want {schema['const']!r} got {node!r}")
+    if "enum" in schema and node not in schema["enum"]:  # type: ignore[operator]
+        errors.append(f"{path}: not in enum {schema['enum']}: {node!r}")
+    if "oneOf" in schema:
+        matched = sum(
+            1 for sub in schema["oneOf"] if _matches(node, sub, root, schemas)  # type: ignore[union-attr]
+        )
+        if matched != 1:
+            errors.append(f"{path}: oneOf matched {matched} branches (must be exactly 1)")
+    if "anyOf" in schema:
+        if not any(_matches(node, sub, root, schemas) for sub in schema["anyOf"]):  # type: ignore[union-attr]
+            errors.append(f"{path}: anyOf matched 0 branches")
+    if "allOf" in schema:
+        for sub in schema["allOf"]:  # type: ignore[union-attr]
+            _check(node, sub, path, root, schemas, errors)
+    if "if" in schema:
+        # conditional application: if `if` matches, `then` must hold, else `else`
+        branch = "then" if _matches(node, schema["if"], root, schemas) else "else"  # type: ignore[arg-type]
+        if branch in schema:
+            _check(node, schema[branch], path, root, schemas, errors)  # type: ignore[arg-type]
+
+    declared = schema.get("type")
+    if declared:
+        types = declared if isinstance(declared, list) else [declared]
+        if not any(_is_type(node, str(t)) for t in types):
+            errors.append(f"{path}: type {declared}, got {type(node).__name__}")
+            return
+    if "pattern" in schema and isinstance(node, str):
+        if not re.search(str(schema["pattern"]), node):
+            errors.append(f"{path}: pattern {schema['pattern']} no match")
+    if "minLength" in schema and isinstance(node, str) and len(node) < int(schema["minLength"]):  # type: ignore[arg-type]
+        errors.append(f"{path}: minLength {schema['minLength']}, got {len(node)}")
+    # `maxLength` is here because an identifier that crosses a product boundary can
+    # be too long for the column the receiver stores it in, and truncating it there
+    # silently collides two records. A bound the format states is a bound both
+    # sides enforce; a bound only the receiver knows is one the sender breaks.
+    if "maxLength" in schema and isinstance(node, str) and len(node) > int(schema["maxLength"]):  # type: ignore[arg-type]
+        errors.append(f"{path}: maxLength {schema['maxLength']}, got {len(node)}")
+
+    # numeric bounds (review §3.1: the schemas use `minimum` etc.)
+    if isinstance(node, (int, float)) and not isinstance(node, bool):
+        if "minimum" in schema and node < schema["minimum"]:  # type: ignore[operator]
+            errors.append(f"{path}: minimum {schema['minimum']}, got {node}")
+        if "maximum" in schema and node > schema["maximum"]:  # type: ignore[operator]
+            errors.append(f"{path}: maximum {schema['maximum']}, got {node}")
+        if "exclusiveMinimum" in schema and node <= schema["exclusiveMinimum"]:  # type: ignore[operator]
+            errors.append(f"{path}: exclusiveMinimum {schema['exclusiveMinimum']}, got {node}")
+
+    if isinstance(node, dict):
+        if "minProperties" in schema and len(node) < int(schema["minProperties"]):  # type: ignore[arg-type]
+            errors.append(f"{path}: minProperties {schema['minProperties']}, got {len(node)}")
+        if "maxProperties" in schema and len(node) > int(schema["maxProperties"]):  # type: ignore[arg-type]
+            errors.append(f"{path}: maxProperties {schema['maxProperties']}, got {len(node)}")
+        # `required` applies whenever present (e.g. a bare {"required": [...]} in an
+        # if/then branch), independent of type/properties
+        for required in schema.get("required", []):  # type: ignore[union-attr]
+            if required not in node:
+                errors.append(f"{path}: missing required '{required}'")
+        if schema.get("type") == "object" or "properties" in schema:
+            props: dict[str, dict[str, object]] = schema.get("properties", {})  # type: ignore[assignment]
+            additional = schema.get("additionalProperties", True)
+            for key, value in node.items():
+                if key in props:
+                    _check(value, props[key], f"{path}.{key}", root, schemas, errors)
+                elif additional is False:
+                    errors.append(f"{path}: additional property '{key}' not allowed")
+                elif isinstance(additional, dict):
+                    _check(value, additional, f"{path}.{key}", root, schemas, errors)
+
+    if isinstance(node, list):
+        if "minItems" in schema and len(node) < int(schema["minItems"]):  # type: ignore[arg-type]
+            errors.append(f"{path}: minItems {schema['minItems']}, got {len(node)}")
+        if "maxItems" in schema and len(node) > int(schema["maxItems"]):  # type: ignore[arg-type]
+            errors.append(f"{path}: maxItems {schema['maxItems']}, got {len(node)}")
+        if "items" in schema:
+            for i, item in enumerate(node):
+                _check(item, schema["items"], f"{path}[{i}]", root, schemas, errors)  # type: ignore[arg-type]
+
+
+def _resolve_ref(
+    schema: dict[str, object],
+    root: dict[str, object],
+    schemas: dict[str, dict[str, object]],
+    path: str,
+    errors: list[str],
+) -> tuple[dict[str, object], dict[str, object]] | None:
+    if "$ref" not in schema:
+        return schema, root
+    ref = str(schema["$ref"])
+    if ref == "#":
+        return root, root
+    if ref.startswith("#/$defs/"):
+        defs: dict[str, dict[str, object]] = root["$defs"]  # type: ignore[assignment]
+        return defs[ref.rsplit("/", 1)[-1]], root
+    if ".schema.json" in ref:
+        name = ref.split(".schema.json")[0].rsplit("/", 1)[-1]
+        target = schemas.get(name)
+        if target is None:
+            errors.append(f"{path}: unknown schema ref {ref}")
+            return None
+        fragment = ref.split("#", 1)[1] if "#" in ref else ""
+        if fragment.startswith("/$defs/"):
+            defs = target["$defs"]  # type: ignore[assignment]
+            return defs[fragment.rsplit("/", 1)[-1]], target
+        return target, target
+    errors.append(f"{path}: unsupported $ref {ref}")
+    return None
+
+
+def _matches(
+    node: object,
+    schema: dict[str, object],
+    root: dict[str, object],
+    schemas: dict[str, dict[str, object]],
+) -> bool:
+    probe: list[str] = []
+    _check(node, schema, "", root, schemas, probe)
+    return not probe
+
+
+def _is_type(node: object, type_name: str) -> bool:
+    # "null" was not in the map, so it fell through to "unknown type → accept
+    # anything" — a schema requiring null would pass for ANY value. And an
+    # unknown/misspelled type silently matched everything. Both now fail closed.
+    if type_name == "null":
+        return node is None
+    expected = _TYPE_MAP.get(type_name)
+    if expected is None:
+        return False  # unknown type name is never a match
+    if type_name in ("number", "integer") and isinstance(node, bool):
+        return False  # bool is an int subclass in Python; not a number here
+    return isinstance(node, expected)

--- a/axor_core/contracts/schemas/_subset_validator.py
+++ b/axor_core/contracts/schemas/_subset_validator.py
@@ -67,9 +67,10 @@ def _check(
         )
         if matched != 1:
             errors.append(f"{path}: oneOf matched {matched} branches (must be exactly 1)")
-    if "anyOf" in schema:
-        if not any(_matches(node, sub, root, schemas) for sub in schema["anyOf"]):  # type: ignore[union-attr]
-            errors.append(f"{path}: anyOf matched 0 branches")
+    if "anyOf" in schema and not any(
+        _matches(node, sub, root, schemas) for sub in schema["anyOf"]  # type: ignore[union-attr]
+    ):
+        errors.append(f"{path}: anyOf matched 0 branches")
     if "allOf" in schema:
         for sub in schema["allOf"]:  # type: ignore[union-attr]
             _check(node, sub, path, root, schemas, errors)
@@ -85,9 +86,10 @@ def _check(
         if not any(_is_type(node, str(t)) for t in types):
             errors.append(f"{path}: type {declared}, got {type(node).__name__}")
             return
-    if "pattern" in schema and isinstance(node, str):
-        if not re.search(str(schema["pattern"]), node):
-            errors.append(f"{path}: pattern {schema['pattern']} no match")
+    if "pattern" in schema and isinstance(node, str) and not re.search(
+        str(schema["pattern"]), node,
+    ):
+        errors.append(f"{path}: pattern {schema['pattern']} no match")
     if "minLength" in schema and isinstance(node, str) and len(node) < int(schema["minLength"]):  # type: ignore[arg-type]
         errors.append(f"{path}: minLength {schema['minLength']}, got {len(node)}")
     # `maxLength` is here because an identifier that crosses a product boundary can

--- a/axor_core/contracts/schemas/cp-deploy.schema.json
+++ b/axor_core/contracts/schemas/cp-deploy.schema.json
@@ -48,7 +48,7 @@
     },
     "runtime_config_hashes": {
       "type": "object",
-      "description": "Per-scenario concrete config identity — what actually ran. Recorded so a reader can pin it; explicitly NOT the config that carries over."
+      "description": "scenario_id → the CONCRETE governor-config hash that scenario's trials ran under. Recorded so a reader can pin it; explicitly NOT the config that carries over to production. Each entry is the hash of the corresponding `runtime_configs` body."
     },
     "tool_manifests": {
       "type": "array",
@@ -136,6 +136,17 @@
           "type": "string",
           "description": "Content hash of `bridge_analysis`."
         }
+      }
+    },
+    "runtime_configs": {
+      "type": "object",
+      "description": "scenario_id → the compiled governor config itself, so a consumer can REPLAY a pin under the control that actually produced its verdict.\n\nOptional for backward compatibility, and today no producer emits it. Without it a consumer has only the tool manifests, from which it must compile a config of its own — and the Control Plane's hand-written compiler and the Lab's disagreed completely: on the same three manifests the Lab produced egress sinks ['send_email'] and the CP produced ['write_file'], because the CP read `side_effecting` as egress and never looked at `effect.resolve`, and dropped the allowlist value-policies entirely (it was never even passed the policy). Every pin whose verdict turned on any of that failed to reproduce and was recorded as `skipped`, blaming the trace.\n\nA compiled config is not something a second implementation should derive. It is carried, and checked against `runtime_config_hashes`.",
+      "additionalProperties": {
+        "type": "object",
+        "description": "The compiled governor config for one scenario, as the Lab's `compiled_governor_config` emits it with `$inputs` EXPANDED — what actually ran. Its `content_hash` must equal this scenario's entry in `runtime_config_hashes`, or it is not that config.",
+        "required": [
+          "egress_sinks"
+        ]
       }
     }
   }

--- a/axor_core/contracts/schemas/cp-deploy.schema.json
+++ b/axor_core/contracts/schemas/cp-deploy.schema.json
@@ -16,7 +16,9 @@
     "source"
   ],
   "properties": {
-    "schema_version": { "const": "axor-cp-deploy/v1" },
+    "schema_version": {
+      "const": "axor-cp-deploy/v1"
+    },
     "verified": {
       "type": "boolean",
       "description": "True only for an evidence-backed export (`export_cp`). A template dump (`export_cp_template`) carries no evidence, sets this false, and the Control Plane refuses it — a config dump must never be mistaken for a proven handoff."
@@ -26,7 +28,10 @@
       "minLength": 1,
       "description": "The kernel identity the evidence was measured under, e.g. `axor-core@0.11.0`. The CP replays a pin only when this matches its own installed build; it will not claim reproduction under a different one."
     },
-    "policy": { "type": "object", "description": "The governance policy carried over verbatim. The Control Plane stores it for an operator to apply and never re-interprets it." },
+    "policy": {
+      "type": "object",
+      "description": "The governance policy carried over verbatim. The Control Plane stores it for an operator to apply and never re-interprets it."
+    },
     "config_hash": {
       "type": "string",
       "minLength": 1,
@@ -37,20 +42,33 @@
       "minLength": 1,
       "description": "The carry-over identity: kernel + policy + the manifest fields that change a verdict, with allowlist `$inputs` left symbolic. This is what transfers to production — not a byte-identical runtime config."
     },
-    "resolved_kernel_fingerprint": { "type": "string", "description": "The resolved kernel BEHAVIOUR identity, including behaviour-changing flags. Emitted by the producer; the consumer does not yet read it." },
-    "runtime_config_hashes": { "type": "object", "description": "Per-scenario concrete config identity — what actually ran. Recorded so a reader can pin it; explicitly NOT the config that carries over." },
+    "resolved_kernel_fingerprint": {
+      "type": "string",
+      "description": "The resolved kernel BEHAVIOUR identity, including behaviour-changing flags. Emitted by the producer; the consumer does not yet read it."
+    },
+    "runtime_config_hashes": {
+      "type": "object",
+      "description": "Per-scenario concrete config identity — what actually ran. Recorded so a reader can pin it; explicitly NOT the config that carries over."
+    },
     "tool_manifests": {
       "type": "array",
       "minItems": 1,
-      "description": "The tool manifests the evidence was produced against. Each is a `tool-manifest/v1` and is validated by that schema, which this kernel also owns — the consumer must not re-state its rules by hand.",
-      "items": { "type": "object" }
+      "description": "The tool manifests the evidence was produced against. Each is validated as a `tool-manifest/v1` by the schema next door, which this kernel also owns — the consumer states none of those rules itself, because a hand-written restatement of a schema is how two definitions of one format come to disagree.",
+      "items": {
+        "$ref": "tool-manifest.schema.json"
+      }
     },
     "regressions": {
       "type": "array",
       "description": "The regression pins the package asks the corpus to adopt. May be empty; a template export carries none.",
       "items": {
         "type": "object",
-        "required": ["trace_id", "expected_verdict", "trace_ref", "expected_sequence"],
+        "required": [
+          "trace_id",
+          "expected_verdict",
+          "trace_ref",
+          "expected_sequence"
+        ],
         "properties": {
           "trace_id": {
             "type": "string",
@@ -58,7 +76,12 @@
             "maxLength": 60,
             "description": "Identifies the pinned trace. Bounded at 60 because the Control Plane stores the pin as `lab:{trace_id}` in a 64-character corpus key: a longer id used to be TRUNCATED there, so two pins agreeing on their first 60 characters became one row and one side of the case was silently lost."
           },
-          "expected_verdict": { "enum": ["ALLOW", "DENY"] },
+          "expected_verdict": {
+            "enum": [
+              "ALLOW",
+              "DENY"
+            ]
+          },
           "trace_ref": {
             "type": "string",
             "pattern": "^sha256:",
@@ -67,7 +90,12 @@
           "expected_sequence": {
             "type": "array",
             "minItems": 1,
-            "items": { "enum": ["ALLOW", "DENY"] },
+            "items": {
+              "enum": [
+                "ALLOW",
+                "DENY"
+              ]
+            },
             "description": "The whole ordered verdict sequence of the pinned trace, so a multi-call trace cannot match on its final verdict alone. Its last entry must equal `expected_verdict`."
           }
         }
@@ -78,19 +106,36 @@
       "description": "trace_id → the trace body, so the Control Plane can REPLAY a pin rather than merely record its hash. Optional for backward compatibility, and today no producer emits it at all: `axor-lab export-cp` has never written this key, so every pin it exports lands `skipped: \"package carries no trace body for this pin\"` against a fully-built consumer. That gap is the reason this schema exists.",
       "additionalProperties": {
         "type": "object",
-        "required": ["trace_id"],
+        "required": [
+          "trace_id"
+        ],
         "description": "A `trace/v1` body. Its `trace_id` must equal the key it is stored under."
       }
     },
     "source": {
       "type": "object",
-      "required": ["bundle_id", "condition_id"],
+      "required": [
+        "bundle_id",
+        "condition_id"
+      ],
       "description": "Where the evidence came from: the Lab bundle and the condition within it.",
       "properties": {
-        "bundle_id": { "type": "string", "minLength": 1 },
-        "condition_id": { "type": "string", "minLength": 1 },
-        "bridge_analysis": { "type": "object", "description": "The recomputed earned-bridge receipt, when the bridge was earned." },
-        "bridge_analysis_ref": { "type": "string", "description": "Content hash of `bridge_analysis`." }
+        "bundle_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "condition_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bridge_analysis": {
+          "type": "object",
+          "description": "The recomputed earned-bridge receipt, when the bridge was earned."
+        },
+        "bridge_analysis_ref": {
+          "type": "string",
+          "description": "Content hash of `bridge_analysis`."
+        }
       }
     }
   }

--- a/axor_core/contracts/schemas/cp-deploy.schema.json
+++ b/axor_core/contracts/schemas/cp-deploy.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://useaxor.net/schemas/cp-deploy.schema.json",
+  "title": "Axor CP Deploy Package",
+  "description": "The Lab → Control Plane handoff: a validated governance config plus the regression pins that earned it. Written by `axor-lab export-cp`, read by `POST /v1/lab/deploy`.\n\nThis schema exists because until now the format had none — the only two statements of it were a producer and a consumer written independently in different repositories, and they had already drifted apart once without anyone noticing: the consumer's whole trace-replay path keys on `regression_traces`, which the producer has never emitted, so every pin a real export carried landed `skipped` for want of a body. A format that crosses a product boundary needs one definition both sides read, not two implementations that happen to agree.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "verified",
+    "kernel",
+    "policy",
+    "config_hash",
+    "parametric_config_hash",
+    "tool_manifests",
+    "regressions",
+    "source"
+  ],
+  "properties": {
+    "schema_version": { "const": "axor-cp-deploy/v1" },
+    "verified": {
+      "type": "boolean",
+      "description": "True only for an evidence-backed export (`export_cp`). A template dump (`export_cp_template`) carries no evidence, sets this false, and the Control Plane refuses it — a config dump must never be mistaken for a proven handoff."
+    },
+    "kernel": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The kernel identity the evidence was measured under, e.g. `axor-core@0.11.0`. The CP replays a pin only when this matches its own installed build; it will not claim reproduction under a different one."
+    },
+    "policy": { "type": "object", "description": "The governance policy carried over verbatim. The Control Plane stores it for an operator to apply and never re-interprets it." },
+    "config_hash": {
+      "type": "string",
+      "minLength": 1,
+      "description": "RFC 8785 fingerprint of {kernel, policy}. The consumer RECOMPUTES it: a package whose recorded fingerprint does not match its own payload is not the measured config and is refused."
+    },
+    "parametric_config_hash": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The carry-over identity: kernel + policy + the manifest fields that change a verdict, with allowlist `$inputs` left symbolic. This is what transfers to production — not a byte-identical runtime config."
+    },
+    "resolved_kernel_fingerprint": { "type": "string", "description": "The resolved kernel BEHAVIOUR identity, including behaviour-changing flags. Emitted by the producer; the consumer does not yet read it." },
+    "runtime_config_hashes": { "type": "object", "description": "Per-scenario concrete config identity — what actually ran. Recorded so a reader can pin it; explicitly NOT the config that carries over." },
+    "tool_manifests": {
+      "type": "array",
+      "minItems": 1,
+      "description": "The tool manifests the evidence was produced against. Each is a `tool-manifest/v1` and is validated by that schema, which this kernel also owns — the consumer must not re-state its rules by hand.",
+      "items": { "type": "object" }
+    },
+    "regressions": {
+      "type": "array",
+      "description": "The regression pins the package asks the corpus to adopt. May be empty; a template export carries none.",
+      "items": {
+        "type": "object",
+        "required": ["trace_id", "expected_verdict", "trace_ref", "expected_sequence"],
+        "properties": {
+          "trace_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 60,
+            "description": "Identifies the pinned trace. Bounded at 60 because the Control Plane stores the pin as `lab:{trace_id}` in a 64-character corpus key: a longer id used to be TRUNCATED there, so two pins agreeing on their first 60 characters became one row and one side of the case was silently lost."
+          },
+          "expected_verdict": { "enum": ["ALLOW", "DENY"] },
+          "trace_ref": {
+            "type": "string",
+            "pattern": "^sha256:",
+            "description": "Content hash of the pinned trace body. When the body is carried in `regression_traces`, the consumer checks it against this before replaying."
+          },
+          "expected_sequence": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "enum": ["ALLOW", "DENY"] },
+            "description": "The whole ordered verdict sequence of the pinned trace, so a multi-call trace cannot match on its final verdict alone. Its last entry must equal `expected_verdict`."
+          }
+        }
+      }
+    },
+    "regression_traces": {
+      "type": "object",
+      "description": "trace_id → the trace body, so the Control Plane can REPLAY a pin rather than merely record its hash. Optional for backward compatibility, and today no producer emits it at all: `axor-lab export-cp` has never written this key, so every pin it exports lands `skipped: \"package carries no trace body for this pin\"` against a fully-built consumer. That gap is the reason this schema exists.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["trace_id"],
+        "description": "A `trace/v1` body. Its `trace_id` must equal the key it is stored under."
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["bundle_id", "condition_id"],
+      "description": "Where the evidence came from: the Lab bundle and the condition within it.",
+      "properties": {
+        "bundle_id": { "type": "string", "minLength": 1 },
+        "condition_id": { "type": "string", "minLength": 1 },
+        "bridge_analysis": { "type": "object", "description": "The recomputed earned-bridge receipt, when the bridge was earned." },
+        "bridge_analysis_ref": { "type": "string", "description": "Content hash of `bridge_analysis`." }
+      }
+    }
+  }
+}

--- a/axor_core/contracts/schemas/predicate.schema.json
+++ b/axor_core/contracts/schemas/predicate.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://useaxor.net/schemas/predicate.schema.json",
-  "title": "Axor Lab Predicate",
+  "title": "Axor Predicate",
   "description": "A typed, structured predicate evaluated over a trace — never natural language. Matches on events, fields and provenance, with boolean composition. Values may reference declared scenario inputs via $inputs.x so a test never scrapes entities out of free-text prompts.\n\nIt lives in the kernel because `tool-manifest` does: a manifest's `effect.resolve[].when` is a predicate, so a tool manifest is not a self-contained artifact without it. A consumer validating a manifest that resolves its effect class from arguments would otherwise be told the reference is unknown and reject a perfectly valid manifest.",
   "oneOf": [
     {

--- a/axor_core/contracts/schemas/predicate.schema.json
+++ b/axor_core/contracts/schemas/predicate.schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://useaxor.net/schemas/predicate.schema.json",
+  "title": "Axor Lab Predicate",
+  "description": "A typed, structured predicate evaluated over a trace — never natural language. Matches on events, fields and provenance, with boolean composition. Values may reference declared scenario inputs via $inputs.x so a test never scrapes entities out of free-text prompts.\n\nIt lives in the kernel because `tool-manifest` does: a manifest's `effect.resolve[].when` is a predicate, so a tool manifest is not a self-contained artifact without it. A consumer validating a manifest that resolves its effect class from arguments would otherwise be told the reference is unknown and reject a perfectly valid manifest.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/event_match"
+    },
+    {
+      "$ref": "#/$defs/bool_all"
+    },
+    {
+      "$ref": "#/$defs/bool_any"
+    },
+    {
+      "$ref": "#/$defs/bool_not"
+    },
+    {
+      "$ref": "#/$defs/sequence"
+    }
+  ],
+  "$defs": {
+    "event_match": {
+      "type": "object",
+      "required": [
+        "event"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "event": {
+          "enum": [
+            "tool_call",
+            "tool_result",
+            "final_output",
+            "gate_decision",
+            "message_send"
+          ]
+        },
+        "tool": {
+          "type": "string",
+          "description": "restrict to a tool id; validated to exist in the scenario's tool set"
+        },
+        "where": {
+          "$ref": "#/$defs/matcher_map"
+        },
+        "count": {
+          "type": "object",
+          "description": "optional cardinality constraint on how many events match; must bound at least one side (min and/or max) so an empty {} — which is a no-op tautology — is rejected",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "properties": {
+            "min": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "max": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    },
+    "matcher_map": {
+      "type": "object",
+      "description": "maps a field address to a typed matcher. Field addresses: args.<name>, result.<path>, output.<path>, prov(args.<name>) for provenance labels.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/matcher"
+      }
+    },
+    "matcher": {
+      "type": "object",
+      "description": "exactly one operator key",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "equal": {
+          "$ref": "#/$defs/operand"
+        },
+        "not_equal": {
+          "$ref": "#/$defs/operand"
+        },
+        "in": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/operand"
+          }
+        },
+        "not_in": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/operand"
+          }
+        },
+        "matches": {
+          "type": "string"
+        },
+        "provenance_is": {
+          "enum": [
+            "trusted",
+            "untrusted_derived",
+            "prompt_given",
+            "sensitive"
+          ]
+        },
+        "gt": {
+          "type": "number"
+        },
+        "lt": {
+          "type": "number"
+        }
+      }
+    },
+    "operand": {
+      "description": "a literal, or a structured reference to a declared scenario input. Structured (not a $-prefixed string) so it can never ambiguously match a literal.",
+      "oneOf": [
+        {
+          "type": [
+            "string",
+            "number",
+            "boolean"
+          ],
+          "not": {
+            "type": "object"
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "input_ref"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "input_ref": {
+              "type": "string",
+              "description": "resolves against scenario.inputs at validation time; unresolved refs fail the check"
+            }
+          }
+        }
+      ]
+    },
+    "bool_all": {
+      "type": "object",
+      "required": [
+        "all"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "all": {
+          "type": "array",
+          "items": {
+            "$ref": "#"
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "bool_any": {
+      "type": "object",
+      "required": [
+        "any"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {
+            "$ref": "#"
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "bool_not": {
+      "type": "object",
+      "required": [
+        "not"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "not": {
+          "$ref": "#"
+        }
+      }
+    },
+    "sequence": {
+      "type": "object",
+      "required": [
+        "sequence"
+      ],
+      "description": "ordered occurrence: each predicate must match in order (e.g. read-secret THEN egress). Order is by event seq / message causality.",
+      "additionalProperties": false,
+      "properties": {
+        "sequence": {
+          "type": "array",
+          "items": {
+            "$ref": "#"
+          },
+          "minItems": 2
+        }
+      }
+    }
+  }
+}

--- a/axor_core/contracts/schemas/tool-manifest.schema.json
+++ b/axor_core/contracts/schemas/tool-manifest.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://useaxor.net/schemas/tool-manifest.schema.json",
-  "title": "Axor Lab Tool Manifest",
+  "title": "Axor Tool Manifest",
   "description": "The runnable contract for one tool. A tool is more than {name, sink}: the runner needs arg/result schemas to bind and type-check, an effect model to gate on, field-level untrusted mapping for per-value provenance, and a simulation/reset strategy so an attack benchmark does not create a real side effect. The effect class is resolved from operation+resource+args, not from the tool name alone — one tool (send_email) can be internal, external, or a draft depending on arguments.",
   "type": "object",
   "required": [

--- a/axor_core/contracts/schemas/tool-manifest.schema.json
+++ b/axor_core/contracts/schemas/tool-manifest.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://useaxor.net/schemas/tool-manifest.schema.json",
+  "title": "Axor Lab Tool Manifest",
+  "description": "The runnable contract for one tool. A tool is more than {name, sink}: the runner needs arg/result schemas to bind and type-check, an effect model to gate on, field-level untrusted mapping for per-value provenance, and a simulation/reset strategy so an attack benchmark does not create a real side effect. The effect class is resolved from operation+resource+args, not from the tool name alone — one tool (send_email) can be internal, external, or a draft depending on arguments.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "id",
+    "args_schema",
+    "effect",
+    "side_effecting"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "tool-manifest/v1"
+    },
+    "id": {
+      "type": "string"
+    },
+    "args_schema": {
+      "type": "object",
+      "description": "JSON Schema for the call arguments; the authoring UI type-checks predicates and injections against this"
+    },
+    "result_schema": {
+      "type": "object",
+      "description": "JSON Schema for the return; addressable as result.<path> in predicates and untrusted_fields"
+    },
+    "effect": {
+      "type": "object",
+      "description": "the consequence model. Rather than a single sink label, effect can be resolved per call from arguments, because the same tool may cross different perimeters.",
+      "required": [
+        "default_class",
+        "driving_args"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "default_class": {
+          "enum": [
+            "READ",
+            "WRITE",
+            "EXPORT",
+            "EXEC"
+          ],
+          "description": "used when no rule matches"
+        },
+        "driving_args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "the arguments whose provenance the gate checks (paper: A(s))"
+        },
+        "resolve": {
+          "type": "array",
+          "description": "ordered rules mapping (operation+resource+args) to an effect class; first match wins. Absent → default_class.",
+          "items": {
+            "type": "object",
+            "required": [
+              "when",
+              "class"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "when": {
+                "$ref": "predicate.schema.json#/$defs/matcher_map",
+                "description": "condition over args, e.g. recipient domain not in company domains → EXPORT"
+              },
+              "class": {
+                "enum": [
+                  "READ",
+                  "WRITE",
+                  "EXPORT",
+                  "EXEC"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "untrusted_fields": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "result fields (result.<path>) whose returned content is attacker-controllable. Field-level, not whole-tool: read_txns.result.transactions[].description may be untrusted while .amount is not. This is what per-value provenance consumes; whole-tool returns_untrusted is only the coarse fallback."
+    },
+    "sensitive_fields": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "result fields that arm the confidentiality floor when read (paper A-floor: sensitive-rooted read)"
+    },
+    "side_effecting": {
+      "type": "boolean",
+      "description": "true → must be simulated or explicitly opted into for real execution; a benchmark must never fire a real EXPORT/EXEC by default"
+    },
+    "simulation": {
+      "type": "object",
+      "description": "how the tool is safely run in Lab. Simulated by default; real side effects are explicit opt-in only.",
+      "additionalProperties": false,
+      "properties": {
+        "supported": {
+          "type": "boolean"
+        },
+        "adapter": {
+          "type": "string",
+          "description": "the simulator that stands in, e.g. 'email_outbox', 'fs_sandbox', 'ledger_stub'"
+        },
+        "real_execution": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "opt_in": {
+              "type": "boolean",
+              "default": false
+            },
+            "requires": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "isolated_test_account",
+                  "resource_allowlist",
+                  "dry_run_confirmed"
+                ]
+              }
+            }
+          },
+          "description": "guardrails that must all hold before a side-effecting tool runs for real"
+        }
+      }
+    },
+    "reset": {
+      "type": "object",
+      "description": "how tool state is restored between trials so trials are independent",
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "enum": [
+            "stateless",
+            "fixture",
+            "snapshot_restore"
+          ]
+        },
+        "fixture_ref": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/axor_core/contracts/schemas/trace.schema.json
+++ b/axor_core/contracts/schemas/trace.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://useaxor.net/schemas/trace.schema.json",
-  "title": "Axor Lab Trace",
+  "title": "Axor Trace",
   "description": "A recorded run of one trial: an ordered event log plus a value ledger carrying per-value provenance. This is the artifact governance verdicts replay over. Provenance is explicit-flow only, built over a closed constructor set (paper O2); it over-taints, never silently under-taints, and is NOT derived by watching a black-box HTTP boundary — it requires the wrapped runtime or an instrumented endpoint that emits value lineage. A plain request/response endpoint cannot produce a conformant trace.",
   "type": "object",
   "required": [

--- a/axor_core/contracts/schemas/trace.schema.json
+++ b/axor_core/contracts/schemas/trace.schema.json
@@ -1,0 +1,375 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://useaxor.net/schemas/trace.schema.json",
+  "title": "Axor Lab Trace",
+  "description": "A recorded run of one trial: an ordered event log plus a value ledger carrying per-value provenance. This is the artifact governance verdicts replay over. Provenance is explicit-flow only, built over a closed constructor set (paper O2); it over-taints, never silently under-taints, and is NOT derived by watching a black-box HTTP boundary — it requires the wrapped runtime or an instrumented endpoint that emits value lineage. A plain request/response endpoint cannot produce a conformant trace.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "trace_id",
+    "trial",
+    "producer",
+    "events",
+    "values"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "trace/v1"
+    },
+    "trace_id": {
+      "type": "string",
+      "description": "stable id; content-hashed for the bundle"
+    },
+    "trial": {
+      "type": "object",
+      "required": [
+        "run_id",
+        "scenario_id",
+        "condition_id",
+        "seed",
+        "repeat_index"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "run_id": {
+          "type": "string"
+        },
+        "scenario_id": {
+          "type": "string"
+        },
+        "condition_id": {
+          "type": "string",
+          "description": "references a Condition; determines whether gates enforced"
+        },
+        "seed": {
+          "type": "string",
+          "description": "pinned seed for this trial; does NOT make the model deterministic, only orders sampling where the provider honors it"
+        },
+        "repeat_index": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "producer": {
+      "type": "object",
+      "description": "who produced this trace and with what provenance capability — this is the honesty boundary for what the trace can support",
+      "required": [
+        "mode",
+        "provenance_fidelity",
+        "kernel_version"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "enum": [
+            "wrapped_code",
+            "instrumented_endpoint",
+            "replay"
+          ],
+          "description": "black_box endpoints are intentionally absent: they cannot emit value lineage and thus cannot produce a conformant trace"
+        },
+        "provenance_fidelity": {
+          "enum": [
+            "explicit_flow_tracked",
+            "heuristic_attribution"
+          ],
+          "description": "explicit_flow_tracked = value lineage from the closed constructor set inside the wrapped loop (paper O2, sound: over-taints not under-taints). heuristic_attribution = a weaker best-effort mapping (e.g. substring/provenance guess) that MUST be labeled and MUST NOT be presented as sound; EvidenceCase renders a warning for it."
+        },
+        "kernel_version": {
+          "type": "string",
+          "description": "e.g. axor-core@0.4.2 — load-bearing: the same trace under a different decide can yield a different verdict"
+        },
+        "runtime": {
+          "type": "string",
+          "description": "adapter/runtime that produced it, e.g. langchain-adapter@0.2"
+        }
+      }
+    },
+    "inputs_digest": {
+      "type": "string",
+      "description": "hash of the scenario inputs+fixtures this trial ran against, so the trace ties back to an exact world"
+    },
+    "events": {
+      "type": "array",
+      "description": "totally ordered within a node by seq; cross-node order (multi-agent) is by message causality, not wall clock",
+      "items": {
+        "$ref": "#/$defs/event"
+      }
+    },
+    "values": {
+      "type": "array",
+      "description": "the value ledger: every governed value with its lineage. A tool-call argument references a value_id; that is how a sink argument is tied to an untrusted source.",
+      "items": {
+        "$ref": "#/$defs/value"
+      }
+    }
+  },
+  "$defs": {
+    "event": {
+      "type": "object",
+      "required": [
+        "seq",
+        "type",
+        "node"
+      ],
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$comment": "discriminated by type: each event variant requires its load-bearing fields, so a gate_decision without a decision or a tool_call_intent without tool/arg_bindings is rejected (review §3.4)",
+          "if": {
+            "properties": {
+              "type": {
+                "const": "gate_decision"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "decision"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "tool_call_intent"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "tool",
+              "arg_bindings"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "tool_result"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "tool"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "seq": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "node": {
+          "type": "string",
+          "description": "which agent/node emitted this (federation-aware; 'root' for single agent)"
+        },
+        "type": {
+          "enum": [
+            "tool_result",
+            "tool_call_intent",
+            "gate_decision",
+            "message_send",
+            "message_recv",
+            "final_output",
+            "spawn",
+            "death"
+          ]
+        },
+        "tool": {
+          "type": "string",
+          "description": "for tool_result / tool_call_intent"
+        },
+        "call_id": {
+          "type": "string",
+          "description": "correlates a tool_call_intent with its gate_decision so replay pairs them by id (not just node order) and can detect a missing or duplicated decision"
+        },
+        "produces_value_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "tool_result: the value_ids minted from this result (per field)"
+        },
+        "arg_bindings": {
+          "type": "object",
+          "description": "tool_call_intent: maps each argument name to the value_id supplying it — THIS is the link that lets the gate see a sink arg's provenance",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "decision": {
+          "$ref": "#/$defs/decision",
+          "description": "present only on gate_decision events"
+        },
+        "payload_ref": {
+          "type": "string",
+          "description": "opaque handle to redacted content; raw bodies are never inlined (paper A-floor: observations only)"
+        }
+      }
+    },
+    "value": {
+      "type": "object",
+      "description": "one value in the ledger. sources + labels are the provenance the gate reads; the model_extraction transformation is the honest record that an LLM produced this value from its inputs.",
+      "required": [
+        "value_id",
+        "labels",
+        "sources"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "value_id": {
+          "type": "string"
+        },
+        "preview": {
+          "type": "string",
+          "description": "short redacted preview for the EvidenceCase UI, never the full body"
+        },
+        "decision_value": {
+          "description": "the EXACT typed value the gate evaluated (the replay-authoritative projection): string, number, boolean, null, array, or object. Distinct from `preview`, which is a truncated UI string. Replay reconstructs the gate's arguments from this, NEVER from `preview`. MAY be omitted for a sensitive value, in which case `canonical_value_hash` pins it and any effect/policy that turns on the value cannot be replayed exactly.",
+          "type": [
+            "string",
+            "number",
+            "boolean",
+            "null",
+            "array",
+            "object"
+          ]
+        },
+        "canonical_value_hash": {
+          "type": "string",
+          "description": "sha256 over the canonical serialization of the exact value; present so an omitted/redacted `decision_value` still binds the trace to a specific value, and so replay can assert value identity."
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "trusted",
+              "untrusted_derived",
+              "prompt_given",
+              "sensitive",
+              "mint"
+            ]
+          },
+          "description": "provenance labels the gate consumes; untrusted_derived on an egress sink is the integrity denial"
+        },
+        "sources": {
+          "type": "array",
+          "description": "causal_root: the set of untrusted sources that explicitly influenced this value (paper O2). A superset is allowed (over-taint); an omission is a soundness bug.",
+          "items": {
+            "type": "object",
+            "required": [
+              "kind"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "kind": {
+                "enum": [
+                  "constant",
+                  "external_read",
+                  "mint",
+                  "parse",
+                  "cross_process_in"
+                ],
+                "description": "the closed constructor set O2 inducts over; adding a constructor requires a join rule or the taint suite fails"
+              },
+              "origin_ref": {
+                "type": "string",
+                "description": "e.g. tool_result:read_txns:field.transactions[3].description"
+              }
+            }
+          }
+        },
+        "transformations": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "model_extraction",
+              "parse",
+              "concat",
+              "copy"
+            ]
+          },
+          "description": "how the value was derived. model_extraction = an LLM produced it from its context; provenance is carried through the loop's labeled values, NOT reconstructed after the fact from a black-box boundary."
+        },
+        "derived_from": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "direct provenance edges: the value_ids this value was derived FROM (e.g. a model_extraction value lists the untrusted context values it was produced from). sources is the transitive causal_root; derived_from is the immediate edge. For a model_extraction under conservative join, derived_from = all untrusted context values live at the call (see provenance-semantics.md)."
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "required": [
+        "verdict",
+        "gate",
+        "driving_value_id"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "verdict": {
+          "enum": [
+            "ALLOW",
+            "DENY"
+          ]
+        },
+        "gate": {
+          "enum": [
+            "capability",
+            "consequence",
+            "value_policies",
+            "degradation",
+            "ssrf",
+            "positional",
+            "carrier",
+            "taint_floor",
+            "adjudicator"
+          ],
+          "description": "the paper's 9-gate sequence; a DENY names the first gate that denied"
+        },
+        "driving_value_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "the argument value the verdict turned on; links the decision to its provenance in the ledger. null ONLY for a fail-closed DENY where no provenance value exists (see driving_unresolved)."
+        },
+        "projection": {
+          "type": "string",
+          "description": "pi(x) the gate decided over, e.g. 'untrusted-derived' — the fiber the whole reframing-equivalence-class maps to"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "driving_unresolved": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "enum": [
+                "no_driving_args",
+                "unresolved_argument"
+              ]
+            },
+            "arg": {
+              "type": "string"
+            }
+          },
+          "description": "present ONLY on a fail-closed DENY whose driving_value_id is null: why no provenance value could be resolved."
+        }
+      }
+    }
+  }
+}

--- a/axor_core/policy/from_record.py
+++ b/axor_core/policy/from_record.py
@@ -1,0 +1,124 @@
+"""Deciding from a RECORDED trace, with the kernel's own predicates.
+
+A recorded trace is not a live call. The Control Plane and the Lab both need to
+ask "what would the kernel decide here?" over events that were written down
+earlier — for export convertibility, for replay, for a counterfactual. Both used
+to answer it by reimplementing the taint floor, which is the thing Rule 0 exists
+to forbid, and which drifts the moment the kernel changes.
+
+They do not have to. The gate is already a pure predicate over two objects:
+
+    taint_gate(tool, NormalizedIntent, CausalRoot, floor_active, ...)
+
+``CausalRoot`` is labels — ``{sources, sensitive}``, ``is_tainted`` is simply
+"carries any external source". A recorded trace stores exactly that per value.
+What a recorded trace does NOT store is content, and it does not need to: the
+content-derivation work belongs to the LEDGER (``ToolCallGovernor`` building
+``CausalRoot``s as a session runs), and by the time an event is written the
+ledger's answer is already in it.
+
+So this module is the seam: recorded JSON in, kernel objects out, and the real
+gate decides. Nothing here interprets governance.
+
+**Reconstruction fails closed.** A field the recording does not carry is not
+defaulted to its permissive value — ``writes_outside_workdir`` absent does not
+mean False, it means unknown, and an unknown that could flip a DENY into an
+ALLOW is refused (:class:`IncompleteRecord`). A caller that would rather skip
+the record than fail must catch it; it must never be able to get a verdict out
+of a trace that cannot support one.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from axor_core.contracts.anomaly import NormalizedIntent
+from axor_core.contracts.taint import TaintSource
+from axor_core.taint.causal_root import CausalRoot
+
+__all__ = [
+    "DECISIVE_NORMALIZED_FIELDS",
+    "IncompleteRecord",
+    "causal_root_from_record",
+    "normalized_from_record",
+]
+
+
+class IncompleteRecord(ValueError):
+    """The recorded event does not carry what a verdict depends on."""
+
+    def __init__(self, missing: list[str], where: str = "") -> None:
+        self.missing = list(missing)
+        at = f" at {where}" if where else ""
+        super().__init__(
+            f"recorded intent{at} is missing {sorted(missing)} — these decide a "
+            f"taint verdict, and absent is not False. Re-record with the full "
+            f"normalized block, or skip this event; it cannot be judged."
+        )
+
+
+# The fields `taint_gate` actually reads off a NormalizedIntent. Absent, each of
+# them could turn a recorded DENY into a replayed ALLOW, so each is required.
+DECISIVE_NORMALIZED_FIELDS = (
+    "destination_kind",
+    "writes_outside_workdir",
+    "executes_generated_code",
+)
+
+# Everything else a NormalizedIntent declares. The gate does not read these, so
+# a record may omit them; they are filled with the neutral value a structural
+# projection has when nothing was observed.
+_NEUTRAL: dict[str, Any] = {
+    "operation": "other",
+    "target_kind": "workdir",
+    "provenance": "unknown",
+    "reads_secret_like_data": False,
+    "after_external_read": False,
+    "after_secret_access": False,
+    "data_flow": "none",
+}
+
+
+def normalized_from_record(
+    tool: str, normalized: dict[str, Any] | None, *, where: str = ""
+) -> NormalizedIntent:
+    """Rebuild the structural projection a recorded call carried.
+
+    Raises :class:`IncompleteRecord` when a field the gate decides on is absent.
+    """
+    record = dict(normalized or {})
+    missing = [f for f in DECISIVE_NORMALIZED_FIELDS if f not in record]
+    if missing:
+        raise IncompleteRecord(missing, where)
+    fields = {**_NEUTRAL, **record}
+    return NormalizedIntent(
+        tool=tool,
+        operation=str(fields["operation"]),
+        target_kind=str(fields["target_kind"]),
+        destination_kind=str(fields["destination_kind"]),
+        provenance=str(fields["provenance"]),
+        reads_secret_like_data=bool(fields["reads_secret_like_data"]),
+        writes_outside_workdir=bool(fields["writes_outside_workdir"]),
+        executes_generated_code=bool(fields["executes_generated_code"]),
+        after_external_read=bool(fields["after_external_read"]),
+        after_secret_access=bool(fields["after_secret_access"]),
+        data_flow=str(fields["data_flow"]),
+    )
+
+
+def causal_root_from_record(root: dict[str, Any] | None) -> CausalRoot:
+    """Rebuild a value's provenance from its recorded root.
+
+    An unrecognised source name is kept as ``UNKNOWN_EXTERNAL`` rather than
+    dropped: forgetting a source is the direction that turns tainted into
+    trusted, and over-tainting is the safe one (the causal-root algebra takes
+    the union for exactly this reason).
+    """
+    record = dict(root or {})
+    sources = set()
+    for name in record.get("sources") or ():
+        try:
+            sources.add(TaintSource(str(name)))
+        except ValueError:
+            sources.add(TaintSource.UNKNOWN_EXTERNAL)
+    return CausalRoot(sources=frozenset(sources), sensitive=bool(record.get("sensitive")))

--- a/axor_core/vectors/__init__.py
+++ b/axor_core/vectors/__init__.py
@@ -1,0 +1,26 @@
+"""Shared conformance vectors, shipped inside the kernel package.
+
+A vector file is only shared if every consumer can read the SAME one. Reaching
+into another product's checkout is not that — it breaks the moment a consumer is
+installed from a wheel, which is how the Lab and the Control Plane consume this
+kernel. So the vectors travel with the package and are loaded by import.
+"""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from typing import Any
+
+__all__ = ["TAINT_FLOOR", "load"]
+
+
+def load(name: str) -> dict[str, Any]:
+    """Read one vector document by name (without the .json suffix)."""
+    text = resources.files(__package__).joinpath(f"{name}.json").read_text("utf-8")
+    return json.loads(text)
+
+
+def TAINT_FLOOR() -> dict[str, Any]:  # noqa: N802 - a named document, not a constant
+    """The taint-floor vectors: what the gate decides, for every consumer."""
+    return load("taint_floor")

--- a/axor_core/vectors/taint_floor.json
+++ b/axor_core/vectors/taint_floor.json
@@ -1,0 +1,124 @@
+{
+  "schema": "axor-taint-floor-vectors/v1",
+  "gate": "taint_gate",
+  "note": [
+    "The shared statement of what the taint floor decides, shipped INSIDE the",
+    "kernel package so every consumer reads the same file without depending on",
+    "another product's checkout. axor-core proves its gate produces these; the",
+    "Control Plane and the Lab prove their record-driven path reproduces them.",
+    "A reimplementation that disagrees here does not ship — that is the whole",
+    "point of the file."
+  ],
+  "vectors": [
+    {
+      "name": "clean value to a plain read is allowed",
+      "tool": "search",
+      "normalized": {"destination_kind": "none", "writes_outside_workdir": false,
+                     "executes_generated_code": false},
+      "root": {"sources": [], "sensitive": false},
+      "egress_sinks": [], "floor_active": false,
+      "expect": "allow"
+    },
+    {
+      "name": "tainted value to a plain read is allowed (no risky consequence)",
+      "tool": "search",
+      "normalized": {"destination_kind": "none", "writes_outside_workdir": false,
+                     "executes_generated_code": false},
+      "root": {"sources": ["web"], "sensitive": false},
+      "egress_sinks": [], "floor_active": false,
+      "expect": "allow"
+    },
+    {
+      "name": "tainted value into an operator-declared egress sink is denied",
+      "tool": "send_email",
+      "normalized": {"destination_kind": "none", "writes_outside_workdir": false,
+                     "executes_generated_code": false},
+      "root": {"sources": ["web"], "sensitive": false},
+      "egress_sinks": ["send_email"], "floor_active": false,
+      "expect": "deny", "category": "taint_enforcement", "axis": "integrity"
+    },
+    {
+      "name": "tainted value to a structurally external destination is denied",
+      "tool": "slack_post",
+      "normalized": {"destination_kind": "external_domain", "writes_outside_workdir": false,
+                     "executes_generated_code": false},
+      "root": {"sources": ["web"], "sensitive": false},
+      "egress_sinks": [], "floor_active": false,
+      "expect": "deny", "category": "taint_enforcement", "axis": "integrity"
+    },
+    {
+      "name": "clean value to the same external destination is allowed",
+      "tool": "slack_post",
+      "normalized": {"destination_kind": "external_domain", "writes_outside_workdir": false,
+                     "executes_generated_code": false},
+      "root": {"sources": [], "sensitive": false},
+      "egress_sinks": [], "floor_active": false,
+      "expect": "allow"
+    },
+    {
+      "name": "tainted value written outside the workdir is denied",
+      "tool": "write_file",
+      "normalized": {"destination_kind": "none", "writes_outside_workdir": true,
+                     "executes_generated_code": false},
+      "root": {"sources": ["file"], "sensitive": false},
+      "egress_sinks": [], "floor_active": false,
+      "expect": "deny", "category": "taint_enforcement", "axis": "integrity"
+    },
+    {
+      "name": "tainted value executed as generated code is denied",
+      "tool": "bash",
+      "normalized": {"destination_kind": "none", "writes_outside_workdir": false,
+                     "executes_generated_code": true},
+      "root": {"sources": ["mcp"], "sensitive": false},
+      "egress_sinks": [], "floor_active": false,
+      "expect": "deny", "category": "taint_enforcement", "axis": "integrity"
+    },
+    {
+      "name": "CLEAN value to egress is denied while the confidentiality floor is up",
+      "tool": "send_email",
+      "normalized": {"destination_kind": "none", "writes_outside_workdir": false,
+                     "executes_generated_code": false},
+      "root": {"sources": [], "sensitive": false},
+      "egress_sinks": ["send_email"], "floor_active": true,
+      "expect": "deny", "category": "taint_enforcement", "axis": "confidentiality"
+    },
+    {
+      "name": "the floor does not gate a non-egress call",
+      "tool": "search",
+      "normalized": {"destination_kind": "none", "writes_outside_workdir": false,
+                     "executes_generated_code": false},
+      "root": {"sources": [], "sensitive": false},
+      "egress_sinks": [], "floor_active": true,
+      "expect": "allow"
+    },
+    {
+      "name": "an unknown source name still taints (over-taint is the safe direction)",
+      "tool": "send_email",
+      "normalized": {"destination_kind": "none", "writes_outside_workdir": false,
+                     "executes_generated_code": false},
+      "root": {"sources": ["something-we-do-not-know"], "sensitive": false},
+      "egress_sinks": ["send_email"], "floor_active": false,
+      "expect": "deny", "category": "taint_enforcement", "axis": "integrity"
+    },
+    {
+      "name": "integrity superseded by a satisfied enum allowlist; the floor is down",
+      "tool": "send_email",
+      "normalized": {"destination_kind": "none", "writes_outside_workdir": false,
+                     "executes_generated_code": false},
+      "root": {"sources": ["web"], "sensitive": false},
+      "egress_sinks": ["send_email"], "floor_active": false,
+      "integrity_superseded": true,
+      "expect": "allow"
+    },
+    {
+      "name": "supersession does NOT lift the confidentiality floor",
+      "tool": "send_email",
+      "normalized": {"destination_kind": "none", "writes_outside_workdir": false,
+                     "executes_generated_code": false},
+      "root": {"sources": ["web"], "sensitive": true},
+      "egress_sinks": ["send_email"], "floor_active": true,
+      "integrity_superseded": true,
+      "expect": "deny", "category": "taint_enforcement", "axis": "confidentiality"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axor-core"
-version = "0.10.2"
+version = "0.11.0"
 description = "Provider-agnostic governance kernel for agent systems"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/contracts/test_schemas.py
+++ b/tests/contracts/test_schemas.py
@@ -1,0 +1,107 @@
+"""The cross-product contract schemas, owned here.
+
+Three artifacts cross a product boundary in this ecosystem: a recorded trace, a
+tool manifest, and the Lab → Control Plane deploy package. None of them had a
+single owner. `trace` and `tool-manifest` were documented as axor-core-owned
+while the only real definitions lived in axor-lab — which kept a directory named
+`_shared_from_axor_core` holding narrower stubs of files this package did not
+have. `cp-deploy` had no schema anywhere, and its producer and consumer, written
+independently in two repositories, had already drifted: the consumer's entire
+trace-replay path keys on `regression_traces`, which the producer has never
+emitted.
+
+These tests are the owner's half. Each consumer proves its own artifacts against
+the same files, loaded by import.
+"""
+from __future__ import annotations
+
+import pytest
+
+from axor_core.contracts.schemas import SCHEMA_NAMES, load, validate
+
+
+@pytest.mark.parametrize("name", SCHEMA_NAMES)
+def test_every_schema_loads_and_declares_itself(name: str) -> None:
+    schema = load(name)
+    assert schema["$id"].endswith(f"{name}.schema.json")
+    assert schema["$schema"].startswith("https://json-schema.org/")
+    assert schema.get("required"), "a schema with no required field constrains nothing"
+
+
+def test_an_unknown_schema_name_is_refused_not_guessed() -> None:
+    with pytest.raises(KeyError, match="unknown schema"):
+        load("cp-deployy")
+
+
+def _package(**over: object) -> dict:
+    base = {
+        "schema_version": "axor-cp-deploy/v1",
+        "verified": True,
+        "kernel": "axor-core@0.11.0",
+        "policy": {"profile": "default"},
+        "config_hash": "sha256:abc",
+        "parametric_config_hash": "sha256:def",
+        "tool_manifests": [{"schema_version": "tool-manifest/v1", "id": "post",
+                            "args_schema": {}, "side_effecting": True,
+                            "effect": {"default_class": "EXPORT",
+                                       "driving_args": ["body"]}}],
+        "regressions": [{"trace_id": "tr1", "expected_verdict": "DENY",
+                         "trace_ref": "sha256:x", "expected_sequence": ["DENY"]}],
+        "source": {"bundle_id": "b1", "condition_id": "c1"},
+    }
+    base.update(over)
+    return base
+
+
+def test_a_well_formed_deploy_package_validates() -> None:
+    assert validate("cp-deploy", _package()) == []
+
+
+def test_every_missing_required_field_is_reported_at_once() -> None:
+    """A rejection is complete. A validator that stops at the first problem makes
+    a caller fix one field, run again, and find the next."""
+    errors = validate("cp-deploy", {})
+    assert len(errors) == len(load("cp-deploy")["required"])
+
+
+def test_a_template_dump_is_distinguishable_from_evidence() -> None:
+    """`verified` is what separates an evidence-backed export from a config
+    template. The schema types it; the consumer refuses false."""
+    assert validate("cp-deploy", _package(verified=False)) == []
+    assert validate("cp-deploy", _package(verified="yes")) != []
+
+
+def test_a_pin_id_too_long_for_the_corpus_key_is_refused() -> None:
+    """The Control Plane stores a pin as `lab:{trace_id}` in a 64-character key.
+    A longer id used to be TRUNCATED there, so two pins agreeing on their first
+    60 characters became one row and one side of the case was lost. The bound
+    belongs in the format, not only in the consumer that discovered it."""
+    fits = _package(regressions=[{"trace_id": "t" * 60, "expected_verdict": "DENY",
+                                  "trace_ref": "sha256:x", "expected_sequence": ["DENY"]}])
+    over = _package(regressions=[{"trace_id": "t" * 61, "expected_verdict": "DENY",
+                                  "trace_ref": "sha256:x", "expected_sequence": ["DENY"]}])
+    assert validate("cp-deploy", fits) == []
+    assert validate("cp-deploy", over) != []
+
+
+def test_a_trace_ref_must_be_a_content_hash() -> None:
+    bad = _package(regressions=[{"trace_id": "tr1", "expected_verdict": "DENY",
+                                 "trace_ref": "whatever", "expected_sequence": ["DENY"]}])
+    assert validate("cp-deploy", bad) != []
+
+
+def test_a_verdict_outside_the_pair_is_refused() -> None:
+    bad = _package(regressions=[{"trace_id": "tr1", "expected_verdict": "MAYBE",
+                                 "trace_ref": "sha256:x", "expected_sequence": ["MAYBE"]}])
+    assert validate("cp-deploy", bad) != []
+
+
+def test_the_tool_manifest_schema_constrains_the_effect_class() -> None:
+    """The consumer used to re-state this enum by hand. It agrees today; nothing
+    kept it so."""
+    ok = {"schema_version": "tool-manifest/v1", "id": "post", "args_schema": {},
+          "side_effecting": True,
+          "effect": {"default_class": "EXPORT", "driving_args": ["b"]}}
+    assert validate("tool-manifest", ok) == []
+    bad = {**ok, "effect": {"default_class": "TRANSMOGRIFY", "driving_args": []}}
+    assert validate("tool-manifest", bad) != []

--- a/tests/contracts/test_schemas.py
+++ b/tests/contracts/test_schemas.py
@@ -163,3 +163,20 @@ def test_a_consumer_can_validate_its_own_schemas_with_this_engine() -> None:
     assert validate_against({"when": {"event": "tool_call"}}, "downstream", schemas) == []
     assert validate_against({}, "downstream", schemas) != []
     assert validate_against({"when": "a sentence"}, "downstream", schemas) != []
+
+
+def test_a_package_may_carry_the_configs_its_pins_ran_under() -> None:
+    """`runtime_configs` exists so a consumer replays a pin under the control
+    that produced its verdict, instead of compiling a second one from the
+    manifests. Two such compilers already disagreed completely in production."""
+    with_configs = _package(
+        runtime_config_hashes={"banking-exfil-01": "sha256:aa"},
+        runtime_configs={"banking-exfil-01": {
+            "kernel": "axor-core@0.11.0", "egress_sinks": ["send_money"],
+            "driving_args": {"send_money": ["recipient"]},
+        }},
+    )
+    assert validate("cp-deploy", with_configs) == []
+    # a body that is not a config at all, and one with no sinks declared
+    assert validate("cp-deploy", _package(runtime_configs={"s": "a string"})) != []
+    assert validate("cp-deploy", _package(runtime_configs={"s": {}})) != []

--- a/tests/contracts/test_schemas.py
+++ b/tests/contracts/test_schemas.py
@@ -25,7 +25,10 @@ def test_every_schema_loads_and_declares_itself(name: str) -> None:
     schema = load(name)
     assert schema["$id"].endswith(f"{name}.schema.json")
     assert schema["$schema"].startswith("https://json-schema.org/")
-    assert schema.get("required"), "a schema with no required field constrains nothing"
+    # A schema that constrains nothing is a file, not a contract. `required` is
+    # how the object-shaped ones say it; `predicate` is a top-level `oneOf` over
+    # its own $defs and says it that way instead.
+    assert schema.get("required") or schema.get("oneOf"), f"{name} constrains nothing"
 
 
 def test_an_unknown_schema_name_is_refused_not_guessed() -> None:
@@ -105,3 +108,38 @@ def test_the_tool_manifest_schema_constrains_the_effect_class() -> None:
     assert validate("tool-manifest", ok) == []
     bad = {**ok, "effect": {"default_class": "TRANSMOGRIFY", "driving_args": []}}
     assert validate("tool-manifest", bad) != []
+
+
+def test_a_deploy_package_validates_its_manifests_as_manifests() -> None:
+    """`tool_manifests` is a `$ref`, not a re-statement.
+
+    The deploy schema first said only `{"type": "object"}` here and left the
+    manifest rules to whoever read it — which is the exact shape of the drift
+    this package exists to end. A broken manifest inside a structurally perfect
+    package must be reported by the deploy schema itself."""
+    broken = _package(tool_manifests=[{"schema_version": "tool-manifest/v1",
+                                       "id": "post", "args_schema": {},
+                                       "side_effecting": True,
+                                       "effect": {"default_class": "TRANSMOGRIFY",
+                                                  "driving_args": []}}])
+    errors = validate("cp-deploy", broken)
+    assert errors and any("tool_manifests[0]" in e for e in errors), errors
+
+
+def test_a_manifest_that_resolves_its_effect_from_args_is_not_rejected() -> None:
+    """`effect.resolve[].when` is a `predicate`, which is why `predicate` is
+    owned here too. While it was not, this manifest — entirely valid — failed
+    with `unknown schema ref predicate.schema.json`: the reference did not
+    resolve, so the strictest kind of manifest was the one that could not pass.
+    """
+    resolving = {
+        "schema_version": "tool-manifest/v1", "id": "send_email",
+        "args_schema": {"type": "object"}, "side_effecting": True,
+        "effect": {
+            "default_class": "WRITE", "driving_args": ["to", "body"],
+            "resolve": [{"when": {"to": {"not_in": ["$inputs.company_domains"]}},
+                         "class": "EXPORT"}],
+        },
+    }
+    assert validate("tool-manifest", resolving) == []
+    assert validate("cp-deploy", _package(tool_manifests=[resolving])) == []

--- a/tests/contracts/test_schemas.py
+++ b/tests/contracts/test_schemas.py
@@ -143,3 +143,23 @@ def test_a_manifest_that_resolves_its_effect_from_args_is_not_rejected() -> None
     }
     assert validate("tool-manifest", resolving) == []
     assert validate("cp-deploy", _package(tool_manifests=[resolving])) == []
+
+
+def test_a_consumer_can_validate_its_own_schemas_with_this_engine() -> None:
+    """`validate_against` and `kernel_schemas` are exported for the consumers
+    that have product-specific schemas of their own — axor-lab has six. They
+    merge these three over their own set and validate everything in one
+    dictionary, because the files reference each other: a Lab `condition` refs
+    `predicate`, and so does a `tool-manifest`. Without this they would keep
+    copies of these three, which is what they used to do."""
+    from axor_core.contracts.schemas import kernel_schemas, validate_against
+
+    downstream = {
+        "type": "object",
+        "required": ["when"],
+        "properties": {"when": {"$ref": "predicate.schema.json"}},
+    }
+    schemas = {**kernel_schemas(), "downstream": downstream}
+    assert validate_against({"when": {"event": "tool_call"}}, "downstream", schemas) == []
+    assert validate_against({}, "downstream", schemas) != []
+    assert validate_against({"when": "a sentence"}, "downstream", schemas) != []

--- a/tests/policy/test_taint_floor_vectors.py
+++ b/tests/policy/test_taint_floor_vectors.py
@@ -1,0 +1,54 @@
+"""The shared taint-floor vectors, proved against the kernel that owns the gate.
+
+`axor_core/vectors/taint_floor.json` is the statement every consumer checks
+itself against. Two of them used to reimplement this gate instead — the Lab's
+reference kernel and the Control Plane's export converter — which is exactly the
+duplication Rule 0 forbids and exactly the thing that drifts silently. The file
+is shipped inside this package so a consumer reads it by import, not by reaching
+into another product's checkout.
+
+This test is the producing half: the real `taint_gate` must decide every vector
+the way the file says. The consuming halves live in the Control Plane and the
+Lab, over the same file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from axor_core.policy.from_record import (
+    causal_root_from_record,
+    normalized_from_record,
+)
+from axor_core.policy.gates import taint_gate
+from axor_core.vectors import TAINT_FLOOR
+
+CASES = TAINT_FLOOR()["vectors"]
+
+
+@pytest.mark.parametrize("vec", CASES, ids=[v["name"] for v in CASES])
+def test_the_kernel_decides_every_vector_as_written(vec: dict) -> None:
+    decision = taint_gate(
+        vec["tool"],
+        normalized_from_record(vec["tool"], vec["normalized"]),
+        causal_root_from_record(vec["root"]),
+        floor_active=bool(vec.get("floor_active")),
+        egress_sinks=frozenset(vec.get("egress_sinks") or ()),
+        integrity_superseded=bool(vec.get("integrity_superseded")),
+    )
+    if vec["expect"] == "allow":
+        assert decision is None, f"expected ALLOW, got DENY: {decision}"
+        return
+    assert decision is not None, "expected DENY, the gate allowed"
+    assert decision.category == vec["category"]
+    # The axis is load-bearing: integrity and confidentiality deny for different
+    # reasons and a caller may only lift one of them.
+    assert vec["axis"] in decision.reason
+
+
+def test_the_vector_file_covers_both_axes_and_both_verdicts() -> None:
+    """A vector file that only ever expects one answer proves nothing."""
+    verdicts = {v["expect"] for v in CASES}
+    axes = {v.get("axis") for v in CASES if v["expect"] == "deny"}
+    assert verdicts == {"allow", "deny"}
+    assert axes == {"integrity", "confidentiality"}


### PR DESCRIPTION
**Merge this first.** axor-wrap, axor-eval and axor-lab all depend on it.

`trace`, `tool-manifest` and `predicate` describe artifacts that cross a product boundary, and axor-lab held its own copies of all three — plus a byte-copy under its package data, plus narrower stubs in a directory named after *this* repo, which did not ship them. A schema with three definitions has none. This release takes ownership, along with the validation engine that reads them: a generic validator had no business belonging to one consumer of the contracts it enforces.

Nine commits. Seven were already on `control-plane-audit-map` and come along unchanged; two are new and finish the move.

### What the two new commits fix

Adopting these copies verbatim would have regressed axor-lab, because its copies kept evolving after the move was first written. Each addition below **already existed** in the copy this repo's file replaces — this is the move finishing, not new surface.

- **`producer.kernel_version` is no longer required.** Governance is a capability, not a stage: a run that declares no kernel produces a trace with no `gate_decision` events and names no kernel version. Requiring it made an ungoverned run unrepresentable.
- **`decision.enforced` is admitted.** DECIDED is not OBEYED — an observe-only arm records a real DENY and executes the call anyway. With `additionalProperties: false` and no such field, both questions collapsed into one, and a reader would count containments that never happened.
- **`gate` lists `message` and `budget`.** The Lab reaches both, so a conformant trace was being rejected by its own owner's schema.
- **The validator names the field on a discriminated union.** A `oneOf` over `{kind: "latency"} | {kind: "budget"} | …` reported "matched 0 of 6 branches" — true and useless. It now reports which branch the discriminant selected and what failed inside it.

### Verification

Full suite before and after these two commits is identical (206 failed / 933 passed — the failures are pre-existing in this sandbox, from optional dependencies that are not installed). Schema-scoped subset likewise identical at 9/154.

Downstream: axor-lab's 1036 tests pass against this build, including its slice examples validated through this engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gz6b7mmMfKhLCGNdpdiw3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz6b7mmMfKhLCGNdpdiw3s)_